### PR TITLE
feat: add Dev Container specification support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Project Is
 
-sdme boots systemd-nspawn containers using overlayfs copy-on-write layers, with OCI registry integration and Kubernetes Pod YAML support for local development and testing. It produces a single binary `sdme` that manages containers from explicit root filesystems, keeping the base rootfs untouched.
+sdme boots systemd-nspawn containers using overlayfs copy-on-write layers, with OCI registry integration, Kubernetes Pod YAML support, and Dev Container specification support for local development and testing. It produces a single binary `sdme` that manages containers from explicit root filesystems, keeping the base rootfs untouched.
 
 Runs on Linux with systemd. Requires root for all operations. Uses kernel overlayfs for copy-on-write storage. By default, containers are overlayfs clones of `/`. Also supports importing rootfs from other distros (Ubuntu, Debian, Fedora, NixOS). Imported rootfs needs systemd and dbus.
 
@@ -83,6 +83,7 @@ The `dist/` directory contains both checked-in packaging files and generated bui
 | `src/mounts.rs` | Bind mount (`BindConfig`) and environment variable (`EnvConfig`) configuration |
 | `src/network.rs` | Network configuration validation and state serialization |
 | `src/security.rs` | Security hardening: `SecurityConfig` (capabilities, seccomp, no-new-privileges, read-only, AppArmor), state file roundtrip, nspawn arg generation, validation |
+| `src/devcontainer/` | Dev Container specification support: devcontainer.json parsing, plan validation, container lifecycle (up/exec/stop/rm), variable substitution, JSONC, lifecycle hooks |
 | `src/kube/` | Kubernetes Pod YAML support: types, plan validation, container creation, kube delete, shared store abstraction for secrets and configmaps |
 | `src/kube/probe/` | Embedded `sdme-kube-probe` binary: CLI entry point, probe runner (failure counting/actions), exec/http/tcp/grpc check implementations |
 | `src/pod.rs` | Pod (shared network namespace) lifecycle: create, list, remove, runtime netns management |
@@ -132,7 +133,7 @@ Dependencies are checked at runtime before use via `system_check::check_dependen
 ## Documentation
 
 - **CLI reference**: `sdme --help` and each subcommand's `--help`. There is no manpage. Each command includes manpage-style reference sections (examples, environment, files, exit status, notes). The help text lives in `*_HELP` constants at the top of `src/main.rs` and is wired to clap via `after_long_help`.
-- **Architecture and design**: `site/content/docs/architecture.md`: comprehensive coverage of overlayfs, systemd integration, networking, pods, OCI, Kubernetes, security hardening, reliability, and all design decisions.
+- **Architecture and design**: `site/content/docs/architecture.md`: comprehensive coverage of overlayfs, systemd integration, networking, pods, OCI, Kubernetes, Dev Containers, security hardening, reliability, and all design decisions.
 - **Security model**: `site/content/docs/security.md`: nspawn isolation compared to Docker/Podman, OCI workload security, Kubernetes pod security.
 - **Tutorials**: `site/content/tutorial/`: getting started, networking, OCI apps, Kubernetes pods, etc.
 

--- a/site/content/docs/architecture.md
+++ b/site/content/docs/architecture.md
@@ -1,6 +1,6 @@
 +++
 title = "Architecture and Design"
-description = "How sdme works: overlayfs, systemd integration, OCI support, and Kubernetes pods."
+description = "How sdme works: overlayfs, systemd integration, OCI support, Kubernetes pods, and Dev Containers."
 weight = 1
 template = "doc.html"
 +++
@@ -29,8 +29,9 @@ container lifecycle through D-Bus.
 The name stands for *Systemd Machine Editor*, and its pronunciation is
 left as an exercise for the reader.
 
-Sections 1-15 cover the core container functionality. Sections 16-17
-cover experimental features: OCI app support and Kubernetes Pod YAML.
+Sections 1-15 cover the core container functionality. Sections 16-18
+cover higher-level features: OCI app support, Kubernetes Pod YAML, and
+Dev Container specification support.
 
 ## 2. Dev Mode: Cloning Your Host
 
@@ -2077,3 +2078,218 @@ Kube pods are tracked with additional state fields:
 
 - No idempotent re-apply: `kube apply` on an existing pod fails; delete
   first, then re-apply
+
+
+## 18. Dev Container Support
+
+sdme implements the [Dev Container specification](https://containers.dev/)
+to create reproducible development environments from
+`.devcontainer/devcontainer.json` files. This bridges the gap between
+sdme's container management and the editor-integrated workflows used by
+VS Code, GitHub Codespaces, and other tools that consume the spec.
+
+The implementation follows the same three-layer architecture as the
+Kubernetes module: raw serde types → validated plan → orchestration.
+
+### Config discovery
+
+`sdme devcontainer up` searches for the config file in standard
+locations, in order:
+
+1. `.devcontainer/devcontainer.json`
+2. `.devcontainer.json` (workspace root)
+3. `.devcontainer/<subdir>/devcontainer.json` (first match)
+
+An explicit path can be provided with `--config-path`.
+
+### JSONC support
+
+Dev Container configs conventionally use JSONC (JSON with comments).
+The parser strips both single-line (`//`) and multi-line (`/* */`)
+comments before passing the content to serde_json. The comment
+stripper is string-aware: it does not strip inside quoted strings,
+so URLs like `https://` in string values are preserved.
+
+### Variable substitution
+
+The following variables are resolved during plan validation:
+
+| Variable | Resolved to |
+|----------|-------------|
+| `${localWorkspaceFolder}` | Absolute host path of the workspace |
+| `${containerWorkspaceFolder}` | The `workspaceFolder` value |
+| `${localWorkspaceFolderBasename}` | Basename of the workspace path |
+| `${localEnv:VAR}` | Host environment variable `VAR` |
+| `${localEnv:VAR:default}` | Host env var with fallback |
+| `${containerEnv:VAR}` | Passed through as `${VAR}` for runtime resolution |
+
+Substitution happens in mount sources/targets, environment variable
+values, and the workspace mount string.
+
+### Container naming
+
+Containers are named `dc-<name>`, where `<name>` is derived from
+the `name` field in devcontainer.json, or the workspace folder
+basename if no name is set. The name is sanitized for sdme:
+
+- Lowercased
+- Non-alphanumeric characters replaced with hyphens
+- Consecutive hyphens collapsed
+- Leading/trailing hyphens stripped
+- Prefixed with `dc-` if it starts with a digit
+- Truncated to 64 characters
+
+The `dc-` prefix prevents collisions with regular sdme containers.
+
+### Image import
+
+When `image` is specified in the config, the OCI image is imported
+as an sdme rootfs named `dc-<name>` using the existing OCI registry
+machinery (`src/import/` and `src/oci/registry.rs`). The import uses
+`OciMode::Base` and `InstallPackages::Yes` so the rootfs includes
+systemd and can boot as an nspawn container.
+
+If the rootfs already exists (from a previous `up`), it is reused
+without re-importing. The `--rebuild` flag forces re-import and
+container recreation.
+
+Dockerfile builds (`build` key) are parsed but not yet implemented.
+The error message directs users to build the image externally and
+reference it via `image`.
+
+### Workspace mount
+
+By default, the host workspace folder is bind-mounted into the
+container at the `workspaceFolder` path (default: `/workspace`):
+
+```
+hostWorkspace:/workspace:rw
+```
+
+The `workspaceMount` key overrides this default. Setting it to an
+empty string disables the automatic workspace mount entirely.
+Additional mounts from the `mounts` array are appended after the
+workspace mount.
+
+### Mount support
+
+Both structured objects and Docker-style strings are supported:
+
+```json
+{
+  "mounts": [
+    { "type": "bind", "source": "/host", "target": "/container", "readonly": true },
+    "source=${localWorkspaceFolder}/.config,target=/home/dev/.config,type=bind"
+  ]
+}
+```
+
+Only bind mounts are supported. Volume and tmpfs mount types are
+skipped with a warning, since sdme's storage model is overlayfs-based,
+not Docker volume-based.
+
+### Port forwarding
+
+Ports from `forwardPorts` are mapped to systemd-nspawn `--port=`
+flags. When any ports are specified, the container is automatically
+given a private network with a virtual ethernet link (`--network-veth`),
+since port forwarding requires network isolation.
+
+Both numeric (`3000`) and string (`"8080:80"`) formats are supported.
+
+### Environment variables
+
+`containerEnv` and `remoteEnv` are merged and passed to the
+container via sdme's `EnvConfig` (which generates `--setenv=`
+nspawn arguments). Variable substitution is applied to values
+before they are stored.
+
+### Lifecycle hooks
+
+The spec defines five lifecycle hooks, executed in order after the
+container boots:
+
+1. **onCreateCommand** — runs once when the container is first created
+2. **updateContentCommand** — runs when created or source code changes
+3. **postCreateCommand** — runs after updateContentCommand
+4. **postStartCommand** — runs every time the container starts
+5. **postAttachCommand** — runs when a tool attaches
+
+Each hook supports three forms:
+
+- **String**: `"npm install"` — single command via `/bin/sh -c`
+- **Array**: `["npm install", "npm build"]` — sequential commands
+- **Object**: `{"install": "npm install", "build": "npm build"}` —
+  parallel commands in the spec, but run sequentially in sdme
+  (sorted by key for deterministic ordering)
+
+Commands are executed inside the running container via
+`machinectl shell`. If `remoteUser` is set, commands run as that
+user.
+
+### Feature installation
+
+The `features` key references Dev Container Features — OCI artifacts
+containing install scripts. The current implementation provides
+simplified support for well-known features from the official
+`ghcr.io/devcontainers/features/` namespace:
+
+| Feature | Implementation |
+|---------|---------------|
+| `node` | Installs Node.js via NodeSource apt repo or dnf |
+| `python` | Installs Python via apt or dnf |
+| `git` | Installs git via apt or dnf |
+
+Features are installed after the container boots and before lifecycle
+hooks run. Feature options (e.g. `"version": "20"`) are extracted
+and used in the install commands.
+
+Custom features and full OCI feature pulling (downloading the
+feature artifact from a registry, extracting `install.sh`, and
+running it with the correct environment) are planned for a future
+release.
+
+### Idempotent up
+
+`sdme devcontainer up` is idempotent:
+
+- If the container exists and is running: prints a message and runs
+  `postStartCommand` (re-entrant).
+- If the container exists but is stopped: starts it and runs
+  `postStartCommand`.
+- If the container does not exist: full creation flow (import image,
+  create container, start, run all lifecycle hooks).
+- With `--rebuild`: deletes the existing container and rootfs, then
+  runs the full creation flow.
+
+### State management
+
+Devcontainer pods are tracked with additional state fields in the
+container's KEY=VALUE state file:
+
+- `DEVCONTAINER=yes` — marks this as a devcontainer
+- `DEVCONTAINER_WORKSPACE=/workspace` — workspace path inside the
+  container (used by `devcontainer exec` for working directory)
+- `DEVCONTAINER_USER=vscode` — user for command execution (from
+  `remoteUser`)
+- `DEVCONTAINER_CONFIG_HASH={sha256}` — hash of the devcontainer.json
+  file (for future change detection)
+
+`sdme devcontainer exec` reads these fields to run commands as the
+correct user and verify the container is a devcontainer.
+
+`sdme devcontainer rm` removes both the container and its rootfs,
+unlike `sdme rm` which preserves the rootfs.
+
+### Limitations
+
+- **Dockerfile builds**: the `build` key is parsed but not executed;
+  use `image` instead
+- **Volume and tmpfs mounts**: only bind mounts are supported
+- **Features**: only well-known features from the official namespace
+  are supported; custom features are skipped
+- **Docker Compose**: the `dockerComposeFile` key is not supported
+- **Customizations**: `customizations.vscode` (extensions, settings)
+  is parsed but not acted on, since sdme is not an IDE
+- **postAttachCommand**: parsed but not automatically triggered (no
+  attach detection); can be run manually

--- a/site/content/tutorial/devcontainers.md
+++ b/site/content/tutorial/devcontainers.md
@@ -1,0 +1,321 @@
++++
+title = "Dev Containers"
+description = "Create reproducible development environments from devcontainer.json files."
+weight = 13
++++
+
+sdme supports the [Dev Container specification](https://containers.dev/),
+the same format used by VS Code Remote Containers, GitHub Codespaces,
+and other tools. Place a `devcontainer.json` in your project and
+`sdme devcontainer up` will create a ready-to-use development
+environment.
+
+See also the [architecture documentation](@/docs/architecture.md#18-dev-container-support)
+for implementation details.
+
+## Prerequisites
+
+Import a base image first. Most devcontainer.json files reference
+an OCI image, and sdme will pull and import it automatically. No
+extra setup is needed beyond having sdme installed.
+
+## A minimal example
+
+Create a `.devcontainer/devcontainer.json` in your project:
+
+```json
+{
+    "image": "ubuntu:22.04",
+    "postCreateCommand": "apt-get update && apt-get install -y git curl"
+}
+```
+
+Bring it up:
+
+```bash
+cd /path/to/project
+sudo sdme devcontainer up
+```
+
+sdme will:
+1. Find `.devcontainer/devcontainer.json`
+2. Pull `ubuntu:22.04` from Docker Hub and import it as a rootfs
+3. Create a container with your project directory bind-mounted at `/workspace`
+4. Start the container
+5. Run `postCreateCommand` inside it
+
+## Running commands
+
+Execute commands inside the devcontainer:
+
+```bash
+sudo sdme devcontainer exec dc-myproject -- npm test
+sudo sdme devcontainer exec dc-myproject -- bash
+```
+
+The container name is `dc-<project>`, derived from the `name` field
+in devcontainer.json or the workspace directory name.
+
+## Workspace mounting
+
+By default, the host workspace folder is mounted at `/workspace`
+inside the container. Override with `workspaceFolder`:
+
+```json
+{
+    "image": "ubuntu:22.04",
+    "workspaceFolder": "/home/dev/app"
+}
+```
+
+To customize the mount itself (e.g. read-only):
+
+```json
+{
+    "image": "ubuntu:22.04",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/app,type=bind,readonly",
+    "workspaceFolder": "/app"
+}
+```
+
+Set `workspaceMount` to an empty string to disable the automatic
+workspace mount entirely.
+
+## User configuration
+
+Run commands as a specific user with `remoteUser`:
+
+```json
+{
+    "image": "ubuntu:22.04",
+    "remoteUser": "vscode",
+    "postCreateCommand": "whoami"
+}
+```
+
+Lifecycle commands and `sdme devcontainer exec` will run as this
+user via `machinectl shell --uid`.
+
+## Environment variables
+
+```json
+{
+    "image": "ubuntu:22.04",
+    "containerEnv": {
+        "NODE_ENV": "development"
+    },
+    "remoteEnv": {
+        "PATH": "${containerEnv:PATH}:/custom/bin",
+        "PROJECT_ROOT": "${containerWorkspaceFolder}"
+    }
+}
+```
+
+Variable substitution is supported:
+- `${localWorkspaceFolder}` — host workspace path
+- `${containerWorkspaceFolder}` — container workspace path
+- `${localWorkspaceFolderBasename}` — workspace directory name
+- `${localEnv:VAR}` — host environment variable
+
+## Additional mounts
+
+Bind-mount host paths into the container:
+
+```json
+{
+    "image": "ubuntu:22.04",
+    "mounts": [
+        {
+            "type": "bind",
+            "source": "${localEnv:HOME}/.ssh",
+            "target": "/home/vscode/.ssh",
+            "readonly": true
+        },
+        "source=${localEnv:HOME}/.gitconfig,target=/root/.gitconfig,type=bind,readonly"
+    ]
+}
+```
+
+Both structured objects and Docker-style strings are supported.
+
+> **Note:** Only bind mounts are supported. Volume and tmpfs mount
+> types are skipped with a warning.
+
+## Port forwarding
+
+Forward ports from the container to the host:
+
+```json
+{
+    "image": "node:20",
+    "forwardPorts": [3000, "8080:80"],
+    "postCreateCommand": "npm install && npm start"
+}
+```
+
+When ports are specified, the container automatically gets a private
+network with a virtual ethernet link. Use `sdme ps` to see the
+container's IP address.
+
+## Lifecycle hooks
+
+Five hooks run at different stages of the container lifecycle:
+
+```json
+{
+    "image": "ubuntu:22.04",
+    "onCreateCommand": "apt-get update && apt-get install -y build-essential",
+    "postCreateCommand": "npm install",
+    "postStartCommand": "echo 'Container started'"
+}
+```
+
+Execution order: `onCreateCommand` → `updateContentCommand` →
+`postCreateCommand` → `postStartCommand` → `postAttachCommand`.
+
+Each hook accepts three formats:
+
+```json
+{
+    "postCreateCommand": "npm install",
+
+    "postCreateCommand": ["npm install", "npm run build"],
+
+    "postCreateCommand": {
+        "install": "npm install",
+        "build": "npm run build"
+    }
+}
+```
+
+## Features
+
+Basic support for well-known Dev Container Features:
+
+```json
+{
+    "image": "ubuntu:22.04",
+    "features": {
+        "ghcr.io/devcontainers/features/node:1": {
+            "version": "20"
+        },
+        "ghcr.io/devcontainers/features/python:1": {
+            "version": "3"
+        },
+        "ghcr.io/devcontainers/features/git:1": {}
+    }
+}
+```
+
+Supported features: `node`, `python`, `git` from the official
+`ghcr.io/devcontainers/features/` namespace. Other features are
+skipped with a warning.
+
+## Capabilities
+
+Add Linux capabilities to the container:
+
+```json
+{
+    "image": "ubuntu:22.04",
+    "capAdd": ["SYS_PTRACE"]
+}
+```
+
+## JSONC support
+
+Comments are supported in devcontainer.json:
+
+```jsonc
+{
+    // Development image
+    "image": "ubuntu:22.04",
+    /* Multi-line
+       comment */
+    "postCreateCommand": "echo hello"
+}
+```
+
+## Managing the devcontainer
+
+```bash
+# Bring up (idempotent — re-runs postStartCommand if already running)
+sudo sdme devcontainer up
+
+# Bring up from a specific workspace
+sudo sdme devcontainer up --workspace-folder /path/to/project
+
+# Force rebuild
+sudo sdme devcontainer up --rebuild
+
+# Execute a command
+sudo sdme devcontainer exec dc-myproject -- make test
+
+# Stop
+sudo sdme devcontainer stop dc-myproject
+
+# Remove (deletes container AND rootfs)
+sudo sdme devcontainer rm dc-myproject
+```
+
+## Full example
+
+A complete devcontainer.json for a Node.js project:
+
+```json
+{
+    "name": "My Node App",
+    "image": "ubuntu:22.04",
+    "workspaceFolder": "/workspace",
+    "remoteUser": "root",
+
+    "features": {
+        "ghcr.io/devcontainers/features/node:1": {
+            "version": "20"
+        },
+        "ghcr.io/devcontainers/features/git:1": {}
+    },
+
+    "forwardPorts": [3000],
+
+    "mounts": [
+        {
+            "type": "bind",
+            "source": "${localEnv:HOME}/.ssh",
+            "target": "/root/.ssh",
+            "readonly": true
+        }
+    ],
+
+    "containerEnv": {
+        "NODE_ENV": "development"
+    },
+
+    "onCreateCommand": "npm install",
+    "postStartCommand": "npm run dev"
+}
+```
+
+```bash
+cd /path/to/project
+sudo sdme devcontainer up
+# Container dc-my-node-app is running with:
+#   - Node.js 20 and git installed
+#   - Port 3000 forwarded
+#   - SSH keys available (read-only)
+#   - npm install completed
+#   - npm run dev started
+
+sudo sdme devcontainer exec dc-my-node-app -- npm test
+```
+
+## Limitations
+
+- **Dockerfile builds**: the `build` key is parsed but not yet
+  supported. Build your image externally and reference it via `image`.
+- **Docker Compose**: `dockerComposeFile` is not supported.
+- **Volume/tmpfs mounts**: only bind mounts work.
+- **Features**: only `node`, `python`, and `git` from the official
+  namespace. Custom features are skipped.
+- **Customizations**: `customizations.vscode` is parsed but not
+  acted on (sdme is not an IDE).

--- a/src/devcontainer/create.rs
+++ b/src/devcontainer/create.rs
@@ -1,0 +1,546 @@
+//! Devcontainer orchestration: up, exec, stop, remove.
+//!
+//! Follows the same pattern as [`crate::kube::create`]: parse config,
+//! set up rootfs, construct [`CreateOptions`], call [`containers::create`],
+//! run lifecycle hooks, and write devcontainer-specific state.
+
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+
+use super::plan::{find_config, load_plan, DevcontainerPlan};
+use crate::{check_interrupted, validate_name, State};
+
+/// Options for `sdme devcontainer up`.
+pub struct DevcontainerUpOptions<'a> {
+    /// Path to the workspace folder on the host (contains .devcontainer/).
+    pub workspace_folder: &'a Path,
+    /// Explicit path to devcontainer.json (overrides auto-detection).
+    pub config_path: Option<&'a Path>,
+    /// Docker Hub credentials `(user, token)` for authenticated pulls.
+    pub docker_credentials: Option<(&'a str, &'a str)>,
+    /// OCI blob cache for registry downloads.
+    pub cache: &'a crate::oci::cache::BlobCache,
+    /// Enable verbose output.
+    pub verbose: bool,
+    /// HTTP configuration for downloads and OCI pulls.
+    pub http: &'a crate::config::HttpConfig,
+    /// Automatically clean up stale transactions.
+    pub auto_gc: bool,
+    /// Per-distro chroot command overrides from config.
+    pub distros: &'a std::collections::HashMap<String, crate::config::DistroCommands>,
+    /// Boot timeout in seconds.
+    pub boot_timeout: u64,
+    /// Maximum tasks for systemd.
+    pub tasks_max: u32,
+    /// Stop timeout (terminate tier) in seconds.
+    pub stop_timeout_terminate: u64,
+    /// Whether to rebuild/recreate even if container exists.
+    pub rebuild: bool,
+    /// Allow interactive prompts.
+    pub interactive: bool,
+}
+
+/// Bring up a devcontainer: find config, import image, create container,
+/// start it, and run lifecycle hooks.
+///
+/// Returns the container name on success.
+pub fn devcontainer_up(datadir: &Path, opts: &DevcontainerUpOptions<'_>) -> Result<String> {
+    let workspace_folder = opts
+        .workspace_folder
+        .canonicalize()
+        .with_context(|| format!("workspace folder not found: {}", opts.workspace_folder.display()))?;
+
+    // 1. Find and parse devcontainer.json.
+    let config_path = match opts.config_path {
+        Some(p) => p.to_path_buf(),
+        None => find_config(&workspace_folder)?,
+    };
+
+    if opts.verbose {
+        eprintln!("config: {}", config_path.display());
+    }
+
+    let plan = load_plan(&config_path, &workspace_folder)?;
+
+    if opts.verbose {
+        eprintln!("devcontainer name: {}", plan.name);
+        if let Some(ref img) = plan.image {
+            eprintln!("image: {img}");
+        }
+    }
+
+    // Check if container already exists.
+    let container_name = format!("dc-{}", plan.name);
+    let state_path = datadir.join("state").join(&container_name);
+    if state_path.exists() {
+        let state = State::read_from(&state_path)?;
+        if state.is_yes("DEVCONTAINER") {
+            if opts.rebuild {
+                eprintln!("rebuilding devcontainer '{container_name}'");
+                devcontainer_rm(datadir, &container_name, opts.verbose)?;
+            } else {
+                // Container exists, check if running.
+                let is_running = crate::systemd::unit_active_state(&container_name)
+                    .map(|s| s == "active")
+                    .unwrap_or(false);
+                if is_running {
+                    eprintln!("devcontainer '{container_name}' is already running");
+                    // Run postStartCommand if defined.
+                    run_lifecycle_commands(
+                        &container_name,
+                        "postStartCommand",
+                        &plan.post_start_commands,
+                        plan.remote_user.as_deref(),
+                        opts.verbose,
+                    )?;
+                    return Ok(container_name);
+                }
+                // Exists but stopped: start it.
+                eprintln!("starting existing devcontainer '{container_name}'");
+                let boot_timeout = std::time::Duration::from_secs(opts.boot_timeout);
+                crate::systemd::start(
+                    datadir,
+                    &container_name,
+                    opts.tasks_max,
+                    boot_timeout.as_secs(),
+                    opts.verbose,
+                )?;
+                crate::systemd::await_boot(&container_name, boot_timeout, opts.verbose)?;
+                run_lifecycle_commands(
+                    &container_name,
+                    "postStartCommand",
+                    &plan.post_start_commands,
+                    plan.remote_user.as_deref(),
+                    opts.verbose,
+                )?;
+                return Ok(container_name);
+            }
+        } else {
+            bail!(
+                "container '{container_name}' already exists but is not a devcontainer; \
+                 remove it first with: sdme rm {container_name}"
+            );
+        }
+    }
+
+    check_interrupted()?;
+
+    // 2. Import OCI image as rootfs (if image-based).
+    let rootfs_name = format!("dc-{}", plan.name);
+    if let Some(ref image) = plan.image {
+        import_image(datadir, &rootfs_name, image, opts)?;
+    } else if plan.build.is_some() {
+        bail!(
+            "Dockerfile builds are not yet supported by sdme devcontainer; \
+             use 'image' instead, or build the image externally and reference it"
+        );
+    }
+
+    check_interrupted()?;
+
+    // 3. Create the container.
+    let create_opts = build_create_options(&plan, &container_name, &rootfs_name)?;
+    let name = crate::containers::create(datadir, &create_opts, opts.verbose)?;
+
+    // 4. Write devcontainer-specific state.
+    let state_path = datadir.join("state").join(&name);
+    let mut state = State::read_from(&state_path)?;
+    state.set("DEVCONTAINER", "yes");
+    state.set("DEVCONTAINER_WORKSPACE", plan.workspace_folder.as_str());
+    if let Some(ref user) = plan.remote_user {
+        state.set("DEVCONTAINER_USER", user);
+    }
+    let config_hash = {
+        use sha2::{Digest, Sha256};
+        let content = std::fs::read(&config_path).unwrap_or_default();
+        let mut hasher = Sha256::new();
+        hasher.update(&content);
+        format!("{:x}", hasher.finalize())
+    };
+    state.set("DEVCONTAINER_CONFIG_HASH", &config_hash);
+    state.write_to(&state_path)?;
+
+    check_interrupted()?;
+
+    // 5. Start the container.
+    eprintln!("starting '{name}'");
+    let boot_timeout = std::time::Duration::from_secs(opts.boot_timeout);
+    crate::systemd::start(
+        datadir,
+        &name,
+        opts.tasks_max,
+        boot_timeout.as_secs(),
+        opts.verbose,
+    )?;
+    crate::systemd::await_boot(&name, boot_timeout, opts.verbose)?;
+
+    check_interrupted()?;
+
+    // 6. Run lifecycle hooks (in spec order).
+    run_lifecycle_commands(
+        &name,
+        "onCreateCommand",
+        &plan.on_create_commands,
+        plan.remote_user.as_deref(),
+        opts.verbose,
+    )?;
+    run_lifecycle_commands(
+        &name,
+        "updateContentCommand",
+        &plan.update_content_commands,
+        plan.remote_user.as_deref(),
+        opts.verbose,
+    )?;
+    run_lifecycle_commands(
+        &name,
+        "postCreateCommand",
+        &plan.post_create_commands,
+        plan.remote_user.as_deref(),
+        opts.verbose,
+    )?;
+    run_lifecycle_commands(
+        &name,
+        "postStartCommand",
+        &plan.post_start_commands,
+        plan.remote_user.as_deref(),
+        opts.verbose,
+    )?;
+
+    // Install features (after container is running).
+    if !plan.features.is_empty() {
+        install_features(&name, &plan, opts.verbose)?;
+    }
+
+    Ok(name)
+}
+
+/// Execute a command inside a running devcontainer.
+pub fn devcontainer_exec(
+    datadir: &Path,
+    name: &str,
+    command: &[String],
+    verbose: bool,
+) -> Result<std::process::ExitStatus> {
+    let state_path = datadir.join("state").join(name);
+    if !state_path.exists() {
+        bail!("devcontainer not found: {name}");
+    }
+    let state = State::read_from(&state_path)?;
+    if !state.is_yes("DEVCONTAINER") {
+        bail!("container '{name}' is not a devcontainer");
+    }
+
+    let remote_user = state.get("DEVCONTAINER_USER");
+    let workspace = state
+        .get("DEVCONTAINER_WORKSPACE")
+        .unwrap_or("/workspace");
+
+    // Build machinectl shell command with user and working directory.
+    exec_in_container(name, command, remote_user, Some(workspace), verbose)
+}
+
+/// Stop a running devcontainer.
+pub fn devcontainer_stop(datadir: &Path, name: &str, verbose: bool) -> Result<()> {
+    let state_path = datadir.join("state").join(name);
+    if !state_path.exists() {
+        bail!("devcontainer not found: {name}");
+    }
+    let state = State::read_from(&state_path)?;
+    if !state.is_yes("DEVCONTAINER") {
+        bail!("container '{name}' is not a devcontainer");
+    }
+
+    crate::containers::stop(name, crate::containers::StopMode::Graceful, 90, verbose)
+}
+
+/// Remove a devcontainer: stop, remove container, remove rootfs.
+pub fn devcontainer_rm(datadir: &Path, name: &str, verbose: bool) -> Result<()> {
+    validate_name(name)?;
+
+    let state_path = datadir.join("state").join(name);
+    if state_path.exists() {
+        let state = State::read_from(&state_path)?;
+        if !state.is_yes("DEVCONTAINER") {
+            bail!("container '{name}' is not a devcontainer; use 'sdme rm' instead");
+        }
+        let rootfs_name = state.rootfs().to_string();
+
+        // Remove the container (stops it if running).
+        crate::containers::remove(datadir, name, verbose)?;
+
+        // Remove the rootfs.
+        if !rootfs_name.is_empty() {
+            let rootfs_path = datadir.join("fs").join(&rootfs_name);
+            if rootfs_path.exists() {
+                if verbose {
+                    eprintln!("removing rootfs: {rootfs_name}");
+                }
+                crate::rootfs::remove(datadir, &rootfs_name, false, verbose)?;
+            }
+        }
+    } else {
+        bail!("devcontainer not found: {name}");
+    }
+
+    Ok(())
+}
+
+// --- Internal helpers ---
+
+/// Import an OCI image as a rootfs for the devcontainer.
+fn import_image(
+    datadir: &Path,
+    rootfs_name: &str,
+    image: &str,
+    opts: &DevcontainerUpOptions<'_>,
+) -> Result<()> {
+    let rootfs_path = datadir.join("fs").join(rootfs_name);
+    if rootfs_path.exists() {
+        if opts.verbose {
+            eprintln!("rootfs '{rootfs_name}' already exists, reusing");
+        }
+        return Ok(());
+    }
+
+    eprintln!("importing image: {image}");
+    let import_opts = crate::import::ImportOptions {
+        source: image,
+        name: rootfs_name,
+        verbose: opts.verbose,
+        force: false,
+        interactive: opts.interactive,
+        install_packages: crate::import::InstallPackages::Yes,
+        oci_mode: crate::import::OciMode::Base,
+        base_fs: None,
+        docker_credentials: opts.docker_credentials,
+        cache: opts.cache,
+        http: opts.http.clone(),
+        auto_gc: opts.auto_gc,
+        distros: opts.distros,
+    };
+    crate::rootfs::import(datadir, &import_opts)
+}
+
+/// Construct CreateOptions from the validated plan.
+fn build_create_options(
+    plan: &DevcontainerPlan,
+    container_name: &str,
+    rootfs_name: &str,
+) -> Result<crate::containers::CreateOptions> {
+    let binds = crate::BindConfig {
+        binds: plan.binds.clone(),
+    };
+    let envs = crate::EnvConfig {
+        vars: plan.env_vars.clone(),
+    };
+
+    // Build network config: private network with port forwarding if ports are defined.
+    let mut network = crate::NetworkConfig::default();
+    if !plan.ports.is_empty() {
+        network.private_network = true;
+        network.network_veth = true;
+        for p in &plan.ports {
+            network.ports.push(p.clone());
+        }
+    }
+
+    // Build security config from capabilities.
+    let mut security = crate::SecurityConfig::default();
+    for cap in &plan.cap_add {
+        let cap_name = if cap.starts_with("CAP_") {
+            cap.clone()
+        } else {
+            format!("CAP_{}", cap.to_uppercase())
+        };
+        security.add_caps.push(cap_name);
+    }
+
+    Ok(crate::containers::CreateOptions {
+        name: Some(container_name.to_string()),
+        rootfs: Some(rootfs_name.to_string()),
+        binds,
+        envs,
+        network,
+        security,
+        ..Default::default()
+    })
+}
+
+/// Run a list of lifecycle commands inside the container.
+fn run_lifecycle_commands(
+    name: &str,
+    hook_name: &str,
+    commands: &[String],
+    remote_user: Option<&str>,
+    verbose: bool,
+) -> Result<()> {
+    if commands.is_empty() {
+        return Ok(());
+    }
+
+    for cmd_str in commands {
+        check_interrupted()?;
+        if verbose {
+            eprintln!("{hook_name}: {cmd_str}");
+        } else {
+            eprintln!("running {hook_name}");
+        }
+        let command = vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            cmd_str.clone(),
+        ];
+        let status =
+            exec_in_container(name, &command, remote_user, None, verbose)?;
+        if !status.success() {
+            let code = status.code().unwrap_or(1);
+            bail!("{hook_name} failed (exit code {code}): {cmd_str}");
+        }
+    }
+    Ok(())
+}
+
+/// Execute a command inside a container, optionally as a specific user.
+fn exec_in_container(
+    name: &str,
+    command: &[String],
+    user: Option<&str>,
+    _workdir: Option<&str>,
+    verbose: bool,
+) -> Result<std::process::ExitStatus> {
+    // Verify the container is running before exec.
+    let active = crate::systemd::unit_active_state(name);
+    if active.as_deref() != Some("active") {
+        anyhow::bail!("container '{name}' is not running");
+    }
+
+    let mut cmd = std::process::Command::new("machinectl");
+    cmd.arg("shell");
+    if let Some(u) = user {
+        cmd.args(["--uid", u]);
+    }
+    cmd.arg(name);
+    if !command.is_empty() {
+        cmd.args(command);
+    }
+    if verbose {
+        eprintln!(
+            "exec: machinectl {}",
+            cmd.get_args()
+                .map(|a| a.to_string_lossy())
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+    }
+    let status = cmd.status().context("failed to run machinectl")?;
+    check_interrupted()?;
+    Ok(status)
+}
+
+/// Install Dev Container Features by running their install scripts inside the container.
+///
+/// Features are OCI artifacts containing install.sh scripts. For the initial
+/// implementation, we support a simplified approach: download the feature
+/// layer, extract install.sh, and run it with the option values as environment
+/// variables.
+fn install_features(
+    name: &str,
+    plan: &DevcontainerPlan,
+    verbose: bool,
+) -> Result<()> {
+    for (feature_ref, options) in &plan.features {
+        check_interrupted()?;
+        eprintln!("installing feature: {feature_ref}");
+
+        // Build environment variables from feature options.
+        let mut env_args = Vec::new();
+        if let Some(obj) = options.as_object() {
+            for (key, value) in obj {
+                let val_str = match value {
+                    serde_json::Value::String(s) => s.clone(),
+                    other => other.to_string(),
+                };
+                let env_key = key.to_uppercase();
+                env_args.push(format!("{env_key}={val_str}"));
+            }
+        }
+
+        // For now, generate a helper script that tries to install the feature.
+        // Full OCI feature pulling would reuse oci::registry, but that's a
+        // follow-up enhancement. For now, we warn and skip unknown features.
+        if feature_ref.starts_with("ghcr.io/devcontainers/features/") {
+            let feature_name = feature_ref
+                .rsplit('/')
+                .next()
+                .unwrap_or(feature_ref)
+                .split(':')
+                .next()
+                .unwrap_or(feature_ref);
+
+            // Generate a simple install command based on well-known features.
+            let install_cmd = match feature_name {
+                "node" => {
+                    let version = env_args
+                        .iter()
+                        .find(|e| e.starts_with("VERSION="))
+                        .map(|e| e.split_once('=').unwrap().1)
+                        .unwrap_or("lts");
+                    format!(
+                        "if command -v apt-get >/dev/null 2>&1; then \
+                         apt-get update && apt-get install -y curl && \
+                         curl -fsSL https://deb.nodesource.com/setup_{version}.x | bash - && \
+                         apt-get install -y nodejs; \
+                         elif command -v dnf >/dev/null 2>&1; then \
+                         dnf install -y nodejs; fi"
+                    )
+                }
+                "python" => {
+                    let version = env_args
+                        .iter()
+                        .find(|e| e.starts_with("VERSION="))
+                        .map(|e| e.split_once('=').unwrap().1)
+                        .unwrap_or("3");
+                    format!(
+                        "if command -v apt-get >/dev/null 2>&1; then \
+                         apt-get update && apt-get install -y python{version} python3-pip; \
+                         elif command -v dnf >/dev/null 2>&1; then \
+                         dnf install -y python{version} python3-pip; fi"
+                    )
+                }
+                "git" => {
+                    "if command -v apt-get >/dev/null 2>&1; then \
+                     apt-get update && apt-get install -y git; \
+                     elif command -v dnf >/dev/null 2>&1; then \
+                     dnf install -y git; fi"
+                        .to_string()
+                }
+                _ => {
+                    eprintln!(
+                        "warning: feature '{feature_ref}' is not natively supported; \
+                         skipping (full OCI feature support is planned)"
+                    );
+                    continue;
+                }
+            };
+
+            let command = vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                install_cmd,
+            ];
+            let status = exec_in_container(name, &command, None, None, verbose)?;
+            if !status.success() {
+                eprintln!(
+                    "warning: feature '{feature_ref}' installation failed (exit code {})",
+                    status.code().unwrap_or(1)
+                );
+            }
+        } else {
+            eprintln!(
+                "warning: custom feature '{feature_ref}' is not yet supported; skipping"
+            );
+        }
+    }
+    Ok(())
+}

--- a/src/devcontainer/create.rs
+++ b/src/devcontainer/create.rs
@@ -46,10 +46,12 @@ pub struct DevcontainerUpOptions<'a> {
 ///
 /// Returns the container name on success.
 pub fn devcontainer_up(datadir: &Path, opts: &DevcontainerUpOptions<'_>) -> Result<String> {
-    let workspace_folder = opts
-        .workspace_folder
-        .canonicalize()
-        .with_context(|| format!("workspace folder not found: {}", opts.workspace_folder.display()))?;
+    let workspace_folder = opts.workspace_folder.canonicalize().with_context(|| {
+        format!(
+            "workspace folder not found: {}",
+            opts.workspace_folder.display()
+        )
+    })?;
 
     // 1. Find and parse devcontainer.json.
     let config_path = match opts.config_path {
@@ -232,9 +234,7 @@ pub fn devcontainer_exec(
     }
 
     let remote_user = state.get("DEVCONTAINER_USER");
-    let workspace = state
-        .get("DEVCONTAINER_WORKSPACE")
-        .unwrap_or("/workspace");
+    let workspace = state.get("DEVCONTAINER_WORKSPACE").unwrap_or("/workspace");
 
     // Build machinectl shell command with user and working directory.
     exec_in_container(name, command, remote_user, Some(workspace), verbose)
@@ -386,13 +386,8 @@ fn run_lifecycle_commands(
         } else {
             eprintln!("running {hook_name}");
         }
-        let command = vec![
-            "/bin/sh".to_string(),
-            "-c".to_string(),
-            cmd_str.clone(),
-        ];
-        let status =
-            exec_in_container(name, &command, remote_user, None, verbose)?;
+        let command = vec!["/bin/sh".to_string(), "-c".to_string(), cmd_str.clone()];
+        let status = exec_in_container(name, &command, remote_user, None, verbose)?;
         if !status.success() {
             let code = status.code().unwrap_or(1);
             bail!("{hook_name} failed (exit code {code}): {cmd_str}");
@@ -444,11 +439,7 @@ fn exec_in_container(
 /// implementation, we support a simplified approach: download the feature
 /// layer, extract install.sh, and run it with the option values as environment
 /// variables.
-fn install_features(
-    name: &str,
-    plan: &DevcontainerPlan,
-    verbose: bool,
-) -> Result<()> {
+fn install_features(name: &str, plan: &DevcontainerPlan, verbose: bool) -> Result<()> {
     for (feature_ref, options) in &plan.features {
         check_interrupted()?;
         eprintln!("installing feature: {feature_ref}");
@@ -508,13 +499,11 @@ fn install_features(
                          dnf install -y python{version} python3-pip; fi"
                     )
                 }
-                "git" => {
-                    "if command -v apt-get >/dev/null 2>&1; then \
+                "git" => "if command -v apt-get >/dev/null 2>&1; then \
                      apt-get update && apt-get install -y git; \
                      elif command -v dnf >/dev/null 2>&1; then \
                      dnf install -y git; fi"
-                        .to_string()
-                }
+                    .to_string(),
                 _ => {
                     eprintln!(
                         "warning: feature '{feature_ref}' is not natively supported; \
@@ -524,11 +513,7 @@ fn install_features(
                 }
             };
 
-            let command = vec![
-                "/bin/sh".to_string(),
-                "-c".to_string(),
-                install_cmd,
-            ];
+            let command = vec!["/bin/sh".to_string(), "-c".to_string(), install_cmd];
             let status = exec_in_container(name, &command, None, None, verbose)?;
             if !status.success() {
                 eprintln!(
@@ -537,9 +522,7 @@ fn install_features(
                 );
             }
         } else {
-            eprintln!(
-                "warning: custom feature '{feature_ref}' is not yet supported; skipping"
-            );
+            eprintln!("warning: custom feature '{feature_ref}' is not yet supported; skipping");
         }
     }
     Ok(())

--- a/src/devcontainer/mod.rs
+++ b/src/devcontainer/mod.rs
@@ -1,0 +1,35 @@
+//! Dev Container specification support for sdme.
+//!
+//! Implements the [Dev Container specification](https://containers.dev/implementors/spec/)
+//! to create development environments from `.devcontainer/devcontainer.json` files.
+//!
+//! # Supported features
+//!
+//! - `image`: OCI image reference (imported as sdme rootfs)
+//! - `workspaceFolder` / `workspaceMount`: workspace directory mapping
+//! - `remoteUser` / `containerUser`: user configuration
+//! - `remoteEnv` / `containerEnv`: environment variables
+//! - `mounts`: additional bind mounts
+//! - `forwardPorts`: port forwarding
+//! - `onCreateCommand`, `postCreateCommand`, `postStartCommand`: lifecycle hooks
+//! - `features`: basic support for well-known Dev Container Features
+//! - `capAdd`: Linux capability additions
+//! - JSONC (JSON with comments) support
+//!
+//! # CLI
+//!
+//! ```text
+//! sdme devcontainer up [--workspace-folder PATH]
+//! sdme devcontainer exec [NAME] -- COMMAND
+//! sdme devcontainer stop [NAME]
+//! sdme devcontainer rm [NAME]
+//! ```
+
+pub(crate) mod create;
+pub(crate) mod plan;
+mod types;
+
+pub use create::{
+    devcontainer_exec, devcontainer_rm, devcontainer_stop, devcontainer_up, DevcontainerUpOptions,
+};
+pub use plan::find_config;

--- a/src/devcontainer/plan.rs
+++ b/src/devcontainer/plan.rs
@@ -89,8 +89,8 @@ fn substitute_vars(s: &str, workspace_folder: &Path, container_workspace: &str) 
             } else {
                 (var_spec, None)
             };
-            let value = std::env::var(var_name)
-                .unwrap_or_else(|_| default.unwrap_or("").to_string());
+            let value =
+                std::env::var(var_name).unwrap_or_else(|_| default.unwrap_or("").to_string());
             let full_pattern = format!("${{localEnv:{}}}", var_spec);
             result = result.replace(&full_pattern, &value);
         } else {
@@ -108,7 +108,10 @@ fn substitute_vars(s: &str, workspace_folder: &Path, container_workspace: &str) 
             break;
         };
         let var_spec = rest[..end].to_string();
-        let var_name = var_spec.split_once(':').map(|(n, _)| n).unwrap_or(&var_spec);
+        let var_name = var_spec
+            .split_once(':')
+            .map(|(n, _)| n)
+            .unwrap_or(&var_spec);
         let replacement = format!("${{{var_name}}}");
         let full_pattern = format!("${{containerEnv:{var_spec}}}");
         result = result.replace(&full_pattern, &replacement);
@@ -133,7 +136,7 @@ fn parse_mount_string(
             match key.trim() {
                 "source" | "src" => source = Some(value.to_string()),
                 "target" | "dst" | "destination" => target = Some(value.to_string()),
-                "type" => {} // we only support bind mounts in sdme
+                "type" => {}        // we only support bind mounts in sdme
                 "consistency" => {} // ignored (Docker-specific)
                 "readonly" | "ro" => {
                     readonly = value.eq_ignore_ascii_case("true") || value == "1";
@@ -200,9 +203,7 @@ fn normalize_port(entry: &PortEntry) -> Result<String> {
             if s.contains(':') {
                 Ok(s.clone())
             } else {
-                let p: u16 = s
-                    .parse()
-                    .with_context(|| format!("invalid port: {s}"))?;
+                let p: u16 = s.parse().with_context(|| format!("invalid port: {s}"))?;
                 Ok(format!("{p}:{p}"))
             }
         }
@@ -245,10 +246,7 @@ pub fn find_config(workspace_folder: &Path) -> Result<PathBuf> {
 }
 
 /// Parse and validate a devcontainer.json file into an executable plan.
-pub(crate) fn load_plan(
-    config_path: &Path,
-    workspace_folder: &Path,
-) -> Result<DevcontainerPlan> {
+pub(crate) fn load_plan(config_path: &Path, workspace_folder: &Path) -> Result<DevcontainerPlan> {
     let content = std::fs::read_to_string(config_path)
         .with_context(|| format!("failed to read {}", config_path.display()))?;
 
@@ -337,9 +335,7 @@ fn validate_and_plan(
         );
     }
 
-    let config_dir = config_path
-        .parent()
-        .unwrap_or(Path::new("."));
+    let config_dir = config_path.parent().unwrap_or(Path::new("."));
 
     // Resolve workspace folder inside container.
     let container_workspace = config
@@ -382,8 +378,7 @@ fn validate_and_plan(
     match workspace_mount {
         Some("") => {} // Explicitly disabled
         Some(custom) => {
-            let mount_str =
-                parse_mount_string(custom, workspace_folder, &container_workspace)?;
+            let mount_str = parse_mount_string(custom, workspace_folder, &container_workspace)?;
             binds.push(mount_str);
         }
         None => {
@@ -401,9 +396,7 @@ fn validate_and_plan(
                 binds.push(bind);
             }
             MountEntry::Object(m) => {
-                if let Some(bind) =
-                    parse_mount_object(m, workspace_folder, &container_workspace)?
-                {
+                if let Some(bind) = parse_mount_object(m, workspace_folder, &container_workspace)? {
                     binds.push(bind);
                 }
             }
@@ -518,9 +511,7 @@ fn sanitize_container_name(name: &str) -> String {
     result = result.trim_matches('-').to_string();
 
     // Ensure starts with a letter.
-    if result.is_empty()
-        || !result.as_bytes()[0].is_ascii_lowercase()
-    {
+    if result.is_empty() || !result.as_bytes()[0].is_ascii_lowercase() {
         result = format!("dc-{result}");
     }
 
@@ -539,7 +530,10 @@ mod tests {
 
     #[test]
     fn test_sanitize_container_name() {
-        assert_eq!(sanitize_container_name("My Dev Container"), "my-dev-container");
+        assert_eq!(
+            sanitize_container_name("My Dev Container"),
+            "my-dev-container"
+        );
         assert_eq!(sanitize_container_name("test_123"), "test-123");
         assert_eq!(sanitize_container_name("123-test"), "dc-123-test");
         assert_eq!(sanitize_container_name("---"), "dc-");
@@ -549,25 +543,13 @@ mod tests {
     #[test]
     fn test_substitute_vars() {
         let ws = Path::new("/home/user/myproject");
-        let result = substitute_vars(
-            "${localWorkspaceFolder}/src",
-            ws,
-            "/workspace",
-        );
+        let result = substitute_vars("${localWorkspaceFolder}/src", ws, "/workspace");
         assert_eq!(result, "/home/user/myproject/src");
 
-        let result = substitute_vars(
-            "${containerWorkspaceFolder}/app",
-            ws,
-            "/workspace",
-        );
+        let result = substitute_vars("${containerWorkspaceFolder}/app", ws, "/workspace");
         assert_eq!(result, "/workspace/app");
 
-        let result = substitute_vars(
-            "${localWorkspaceFolderBasename}",
-            ws,
-            "/workspace",
-        );
+        let result = substitute_vars("${localWorkspaceFolderBasename}", ws, "/workspace");
         assert_eq!(result, "myproject");
     }
 
@@ -597,7 +579,10 @@ mod tests {
 
     #[test]
     fn test_normalize_port() {
-        assert_eq!(normalize_port(&PortEntry::Number(3000)).unwrap(), "3000:3000");
+        assert_eq!(
+            normalize_port(&PortEntry::Number(3000)).unwrap(),
+            "3000:3000"
+        );
         assert_eq!(
             normalize_port(&PortEntry::String("8080:80".into())).unwrap(),
             "8080:80"
@@ -645,10 +630,7 @@ mod tests {
             "/workspace",
         )
         .unwrap();
-        assert_eq!(
-            result,
-            "/home/user/project/.config:/home/dev/.config:ro"
-        );
+        assert_eq!(result, "/home/user/project/.config:/home/dev/.config:ro");
     }
 
     #[test]

--- a/src/devcontainer/plan.rs
+++ b/src/devcontainer/plan.rs
@@ -1,0 +1,692 @@
+//! Validation layer: convert raw [`DevcontainerConfig`] into a validated [`DevcontainerPlan`].
+//!
+//! Variable substitution, mount parsing, port normalization, and lifecycle
+//! command flattening all happen here so the orchestration layer can consume
+//! a fully-validated plan without re-checking.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+
+use super::types::*;
+
+/// A validated, ready-to-execute devcontainer plan.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub(crate) struct DevcontainerPlan {
+    /// Human-readable name (falls back to workspace directory name).
+    pub name: String,
+    /// Container source: OCI image reference.
+    pub image: Option<String>,
+    /// Container source: Dockerfile build.
+    pub build: Option<BuildPlan>,
+    /// Absolute path inside the container for the workspace.
+    pub workspace_folder: String,
+    /// User to run as inside the container.
+    pub remote_user: Option<String>,
+    /// User for container creation (file ownership).
+    pub container_user: Option<String>,
+    /// Bind mounts (host:container:mode).
+    pub binds: Vec<String>,
+    /// Port forwards (host:container).
+    pub ports: Vec<String>,
+    /// Runtime environment variables.
+    pub env_vars: Vec<String>,
+    /// Build-time environment variables.
+    pub container_env_vars: Vec<String>,
+    /// Lifecycle hooks flattened to shell commands.
+    pub on_create_commands: Vec<String>,
+    pub update_content_commands: Vec<String>,
+    pub post_create_commands: Vec<String>,
+    pub post_start_commands: Vec<String>,
+    pub post_attach_commands: Vec<String>,
+    /// Capabilities to add.
+    pub cap_add: Vec<String>,
+    /// Features to install (reference -> options JSON).
+    pub features: HashMap<String, serde_json::Value>,
+    /// Whether the container uses init.
+    pub init: bool,
+    /// Whether the container is privileged.
+    pub privileged: bool,
+}
+
+/// Validated Dockerfile build configuration.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub(crate) struct BuildPlan {
+    /// Absolute path to the Dockerfile.
+    pub dockerfile: PathBuf,
+    /// Absolute path to the build context directory.
+    pub context: PathBuf,
+    /// Build arguments.
+    pub args: HashMap<String, String>,
+    /// Target build stage.
+    pub target: Option<String>,
+}
+
+/// Substitute `${localWorkspaceFolder}`, `${containerWorkspaceFolder}`,
+/// `${localWorkspaceFolderBasename}`, and `${localEnv:VAR}` in a string.
+fn substitute_vars(s: &str, workspace_folder: &Path, container_workspace: &str) -> String {
+    let workspace_str = workspace_folder.to_string_lossy();
+    let basename = workspace_folder
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+
+    let mut result = s.to_string();
+    result = result.replace("${localWorkspaceFolder}", &workspace_str);
+    result = result.replace("${containerWorkspaceFolder}", container_workspace);
+    result = result.replace("${localWorkspaceFolderBasename}", &basename);
+
+    // Handle ${localEnv:VAR} and ${localEnv:VAR:default}
+    while let Some(start) = result.find("${localEnv:") {
+        let rest = &result[start + "${localEnv:".len()..];
+        if let Some(end) = rest.find('}') {
+            let var_spec = &rest[..end];
+            let (var_name, default) = if let Some((name, def)) = var_spec.split_once(':') {
+                (name, Some(def))
+            } else {
+                (var_spec, None)
+            };
+            let value = std::env::var(var_name)
+                .unwrap_or_else(|_| default.unwrap_or("").to_string());
+            let full_pattern = format!("${{localEnv:{}}}", var_spec);
+            result = result.replace(&full_pattern, &value);
+        } else {
+            break;
+        }
+    }
+
+    // Handle ${containerEnv:VAR} - resolved at runtime, pass through as $VAR
+    loop {
+        let Some(start) = result.find("${containerEnv:") else {
+            break;
+        };
+        let rest = &result[start + "${containerEnv:".len()..];
+        let Some(end) = rest.find('}') else {
+            break;
+        };
+        let var_spec = rest[..end].to_string();
+        let var_name = var_spec.split_once(':').map(|(n, _)| n).unwrap_or(&var_spec);
+        let replacement = format!("${{{var_name}}}");
+        let full_pattern = format!("${{containerEnv:{var_spec}}}");
+        result = result.replace(&full_pattern, &replacement);
+    }
+
+    result
+}
+
+/// Parse a Docker-style mount string: "source=...,target=...,type=bind[,readonly]".
+fn parse_mount_string(
+    s: &str,
+    workspace_folder: &Path,
+    container_workspace: &str,
+) -> Result<String> {
+    let s = substitute_vars(s, workspace_folder, container_workspace);
+    let mut source = None;
+    let mut target = None;
+    let mut readonly = false;
+
+    for part in s.split(',') {
+        if let Some((key, value)) = part.split_once('=') {
+            match key.trim() {
+                "source" | "src" => source = Some(value.to_string()),
+                "target" | "dst" | "destination" => target = Some(value.to_string()),
+                "type" => {} // we only support bind mounts in sdme
+                "consistency" => {} // ignored (Docker-specific)
+                "readonly" | "ro" => {
+                    readonly = value.eq_ignore_ascii_case("true") || value == "1";
+                }
+                _ => {}
+            }
+        } else if part.trim() == "readonly" || part.trim() == "ro" {
+            readonly = true;
+        }
+    }
+
+    let source = source.context("mount string missing 'source' field")?;
+    let target = target.context("mount string missing 'target' field")?;
+    let mode = if readonly { "ro" } else { "rw" };
+    Ok(format!("{source}:{target}:{mode}"))
+}
+
+/// Parse a structured mount object into a bind string.
+fn parse_mount_object(
+    m: &MountObject,
+    workspace_folder: &Path,
+    container_workspace: &str,
+) -> Result<Option<String>> {
+    let mount_type = m.mount_type.as_deref().unwrap_or("bind");
+    if mount_type != "bind" {
+        // sdme only supports bind mounts; skip volume/tmpfs with a warning.
+        eprintln!(
+            "warning: skipping unsupported mount type '{}' for target '{}'",
+            mount_type, m.target
+        );
+        return Ok(None);
+    }
+    let source = m
+        .source
+        .as_deref()
+        .context("bind mount missing 'source' field")?;
+    let source = substitute_vars(source, workspace_folder, container_workspace);
+    let target = substitute_vars(&m.target, workspace_folder, container_workspace);
+    let mode = if m.readonly { "ro" } else { "rw" };
+    Ok(Some(format!("{source}:{target}:{mode}")))
+}
+
+/// Flatten a lifecycle command into a list of shell command strings.
+fn flatten_lifecycle(cmd: &LifecycleCommand) -> Vec<String> {
+    match cmd {
+        LifecycleCommand::String(s) => vec![s.clone()],
+        LifecycleCommand::Array(arr) => arr.clone(),
+        LifecycleCommand::Object(map) => {
+            // Object commands are parallel in the spec, but we run them
+            // sequentially since sdme doesn't have a parallel executor.
+            // Sort by key for deterministic ordering.
+            let mut pairs: Vec<_> = map.iter().collect();
+            pairs.sort_by_key(|(k, _)| *k);
+            pairs.into_iter().map(|(_, v)| v.clone()).collect()
+        }
+    }
+}
+
+/// Normalize a port entry into a "host:container" string.
+fn normalize_port(entry: &PortEntry) -> Result<String> {
+    match entry {
+        PortEntry::Number(p) => Ok(format!("{p}:{p}")),
+        PortEntry::String(s) => {
+            if s.contains(':') {
+                Ok(s.clone())
+            } else {
+                let p: u16 = s
+                    .parse()
+                    .with_context(|| format!("invalid port: {s}"))?;
+                Ok(format!("{p}:{p}"))
+            }
+        }
+    }
+}
+
+/// Find the devcontainer.json file starting from the workspace folder.
+///
+/// Searches in order:
+/// 1. `.devcontainer/devcontainer.json`
+/// 2. `.devcontainer.json`
+/// 3. `.devcontainer/<subdir>/devcontainer.json` (first match)
+pub fn find_config(workspace_folder: &Path) -> Result<PathBuf> {
+    let primary = workspace_folder.join(".devcontainer/devcontainer.json");
+    if primary.is_file() {
+        return Ok(primary);
+    }
+    let root_config = workspace_folder.join(".devcontainer.json");
+    if root_config.is_file() {
+        return Ok(root_config);
+    }
+    // Look for subdirectories under .devcontainer/
+    let devcontainer_dir = workspace_folder.join(".devcontainer");
+    if devcontainer_dir.is_dir() {
+        if let Ok(entries) = std::fs::read_dir(&devcontainer_dir) {
+            for entry in entries.flatten() {
+                if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                    let sub = entry.path().join("devcontainer.json");
+                    if sub.is_file() {
+                        return Ok(sub);
+                    }
+                }
+            }
+        }
+    }
+    bail!(
+        "no devcontainer.json found in {}",
+        workspace_folder.display()
+    )
+}
+
+/// Parse and validate a devcontainer.json file into an executable plan.
+pub(crate) fn load_plan(
+    config_path: &Path,
+    workspace_folder: &Path,
+) -> Result<DevcontainerPlan> {
+    let content = std::fs::read_to_string(config_path)
+        .with_context(|| format!("failed to read {}", config_path.display()))?;
+
+    // Strip JSON comments (// and /* */) for JSONC compatibility.
+    let content = strip_json_comments(&content);
+
+    let config: DevcontainerConfig = serde_json::from_str(&content)
+        .with_context(|| format!("failed to parse {}", config_path.display()))?;
+
+    validate_and_plan(config, config_path, workspace_folder)
+}
+
+/// Strip single-line (//) and multi-line (/* */) comments from JSON content.
+/// This provides basic JSONC support for devcontainer.json files.
+fn strip_json_comments(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    let mut in_string = false;
+
+    while let Some(&ch) = chars.peek() {
+        if in_string {
+            result.push(ch);
+            chars.next();
+            if ch == '\\' {
+                // Skip escaped character
+                if let Some(&next) = chars.peek() {
+                    result.push(next);
+                    chars.next();
+                }
+            } else if ch == '"' {
+                in_string = false;
+            }
+        } else if ch == '"' {
+            in_string = true;
+            result.push(ch);
+            chars.next();
+        } else if ch == '/' {
+            chars.next();
+            match chars.peek() {
+                Some(&'/') => {
+                    // Single-line comment: skip until newline
+                    for c in chars.by_ref() {
+                        if c == '\n' {
+                            result.push('\n');
+                            break;
+                        }
+                    }
+                }
+                Some(&'*') => {
+                    // Multi-line comment: skip until */
+                    chars.next();
+                    let mut prev = ' ';
+                    for c in chars.by_ref() {
+                        if prev == '*' && c == '/' {
+                            break;
+                        }
+                        if c == '\n' {
+                            result.push('\n');
+                        }
+                        prev = c;
+                    }
+                }
+                _ => {
+                    result.push('/');
+                }
+            }
+        } else {
+            result.push(ch);
+            chars.next();
+        }
+    }
+    result
+}
+
+/// Convert a parsed config into a validated plan.
+fn validate_and_plan(
+    config: DevcontainerConfig,
+    config_path: &Path,
+    workspace_folder: &Path,
+) -> Result<DevcontainerPlan> {
+    // Must have either image or build.
+    if config.image.is_none() && config.build.is_none() {
+        bail!(
+            "{}: must specify either 'image' or 'build'",
+            config_path.display()
+        );
+    }
+
+    let config_dir = config_path
+        .parent()
+        .unwrap_or(Path::new("."));
+
+    // Resolve workspace folder inside container.
+    let container_workspace = config
+        .workspace_folder
+        .clone()
+        .unwrap_or_else(|| "/workspace".to_string());
+
+    // Resolve name.
+    let name = config.name.unwrap_or_else(|| {
+        workspace_folder
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "devcontainer".to_string())
+    });
+
+    // Sanitize name for sdme (lowercase, alphanumeric + hyphens).
+    let name = sanitize_container_name(&name);
+
+    // Resolve build config.
+    let build = config.build.map(|b| {
+        let dockerfile = config_dir.join(&b.dockerfile);
+        let context = b
+            .context
+            .as_ref()
+            .map(|c| config_dir.join(c))
+            .unwrap_or_else(|| config_dir.to_path_buf());
+        BuildPlan {
+            dockerfile,
+            context,
+            args: b.args,
+            target: b.target,
+        }
+    });
+
+    // Parse mounts.
+    let mut binds = Vec::new();
+
+    // Default workspace mount: bind the workspace folder into the container.
+    let workspace_mount = config.workspace_mount.as_deref();
+    match workspace_mount {
+        Some("") => {} // Explicitly disabled
+        Some(custom) => {
+            let mount_str =
+                parse_mount_string(custom, workspace_folder, &container_workspace)?;
+            binds.push(mount_str);
+        }
+        None => {
+            // Default: bind workspace folder to containerWorkspaceFolder
+            let ws = workspace_folder.to_string_lossy();
+            binds.push(format!("{ws}:{container_workspace}:rw"));
+        }
+    }
+
+    // Additional mounts.
+    for mount in &config.mounts {
+        match mount {
+            MountEntry::String(s) => {
+                let bind = parse_mount_string(s, workspace_folder, &container_workspace)?;
+                binds.push(bind);
+            }
+            MountEntry::Object(m) => {
+                if let Some(bind) =
+                    parse_mount_object(m, workspace_folder, &container_workspace)?
+                {
+                    binds.push(bind);
+                }
+            }
+        }
+    }
+
+    // Parse ports.
+    let mut ports = Vec::new();
+    for entry in &config.forward_ports {
+        ports.push(normalize_port(entry)?);
+    }
+
+    // Parse environment variables.
+    let mut env_vars = Vec::new();
+    if let Some(ref env) = config.container_env {
+        for (k, v) in env {
+            let v = substitute_vars(v, workspace_folder, &container_workspace);
+            env_vars.push(format!("{k}={v}"));
+        }
+    }
+    if let Some(ref env) = config.remote_env {
+        for (k, v) in env {
+            let v = substitute_vars(v, workspace_folder, &container_workspace);
+            env_vars.push(format!("{k}={v}"));
+        }
+    }
+
+    // Container env vars (for build-time).
+    let container_env_vars = config
+        .container_env
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(k, v)| {
+            let v = substitute_vars(&v, workspace_folder, &container_workspace);
+            format!("{k}={v}")
+        })
+        .collect();
+
+    // Flatten lifecycle hooks.
+    let on_create_commands = config
+        .on_create_command
+        .as_ref()
+        .map(flatten_lifecycle)
+        .unwrap_or_default();
+    let update_content_commands = config
+        .update_content_command
+        .as_ref()
+        .map(flatten_lifecycle)
+        .unwrap_or_default();
+    let post_create_commands = config
+        .post_create_command
+        .as_ref()
+        .map(flatten_lifecycle)
+        .unwrap_or_default();
+    let post_start_commands = config
+        .post_start_command
+        .as_ref()
+        .map(flatten_lifecycle)
+        .unwrap_or_default();
+    let post_attach_commands = config
+        .post_attach_command
+        .as_ref()
+        .map(flatten_lifecycle)
+        .unwrap_or_default();
+
+    Ok(DevcontainerPlan {
+        name,
+        image: config.image,
+        build,
+        workspace_folder: container_workspace,
+        remote_user: config.remote_user,
+        container_user: config.container_user,
+        binds,
+        ports,
+        env_vars,
+        container_env_vars,
+        on_create_commands,
+        update_content_commands,
+        post_create_commands,
+        post_start_commands,
+        post_attach_commands,
+        cap_add: config.cap_add,
+        features: config.features,
+        init: config.init.unwrap_or(false),
+        privileged: config.privileged.unwrap_or(false),
+    })
+}
+
+/// Convert a human-readable name to a valid sdme container name.
+///
+/// Lowercase, replace non-alphanumeric with hyphens, collapse hyphens,
+/// strip leading/trailing hyphens, ensure starts with a letter.
+fn sanitize_container_name(name: &str) -> String {
+    let mut result: String = name
+        .to_lowercase()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+
+    // Collapse consecutive hyphens.
+    while result.contains("--") {
+        result = result.replace("--", "-");
+    }
+
+    // Strip leading/trailing hyphens.
+    result = result.trim_matches('-').to_string();
+
+    // Ensure starts with a letter.
+    if result.is_empty()
+        || !result.as_bytes()[0].is_ascii_lowercase()
+    {
+        result = format!("dc-{result}");
+    }
+
+    // Truncate to 64 chars.
+    if result.len() > 64 {
+        result.truncate(64);
+        result = result.trim_end_matches('-').to_string();
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_container_name() {
+        assert_eq!(sanitize_container_name("My Dev Container"), "my-dev-container");
+        assert_eq!(sanitize_container_name("test_123"), "test-123");
+        assert_eq!(sanitize_container_name("123-test"), "dc-123-test");
+        assert_eq!(sanitize_container_name("---"), "dc-");
+        assert_eq!(sanitize_container_name("Hello World!"), "hello-world");
+    }
+
+    #[test]
+    fn test_substitute_vars() {
+        let ws = Path::new("/home/user/myproject");
+        let result = substitute_vars(
+            "${localWorkspaceFolder}/src",
+            ws,
+            "/workspace",
+        );
+        assert_eq!(result, "/home/user/myproject/src");
+
+        let result = substitute_vars(
+            "${containerWorkspaceFolder}/app",
+            ws,
+            "/workspace",
+        );
+        assert_eq!(result, "/workspace/app");
+
+        let result = substitute_vars(
+            "${localWorkspaceFolderBasename}",
+            ws,
+            "/workspace",
+        );
+        assert_eq!(result, "myproject");
+    }
+
+    #[test]
+    fn test_strip_json_comments() {
+        let input = r#"{
+            // This is a comment
+            "key": "value", // inline comment
+            /* multi-line
+               comment */
+            "key2": "value2"
+        }"#;
+        let result = strip_json_comments(input);
+        assert!(!result.contains("// This is a comment"));
+        assert!(!result.contains("inline comment"));
+        assert!(!result.contains("multi-line"));
+        assert!(result.contains(r#""key": "value""#));
+        assert!(result.contains(r#""key2": "value2""#));
+    }
+
+    #[test]
+    fn test_strip_json_comments_preserves_strings() {
+        let input = r#"{ "url": "https://example.com" }"#;
+        let result = strip_json_comments(input);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn test_normalize_port() {
+        assert_eq!(normalize_port(&PortEntry::Number(3000)).unwrap(), "3000:3000");
+        assert_eq!(
+            normalize_port(&PortEntry::String("8080:80".into())).unwrap(),
+            "8080:80"
+        );
+        assert_eq!(
+            normalize_port(&PortEntry::String("3000".into())).unwrap(),
+            "3000:3000"
+        );
+    }
+
+    #[test]
+    fn test_flatten_lifecycle_string() {
+        let cmd = LifecycleCommand::String("npm install".into());
+        assert_eq!(flatten_lifecycle(&cmd), vec!["npm install"]);
+    }
+
+    #[test]
+    fn test_flatten_lifecycle_array() {
+        let cmd = LifecycleCommand::Array(vec!["a".into(), "b".into()]);
+        assert_eq!(flatten_lifecycle(&cmd), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_flatten_lifecycle_object() {
+        let mut map = HashMap::new();
+        map.insert("beta".into(), "cmd-b".into());
+        map.insert("alpha".into(), "cmd-a".into());
+        let cmd = LifecycleCommand::Object(map);
+        let result = flatten_lifecycle(&cmd);
+        // Should be sorted by key
+        assert_eq!(result, vec!["cmd-a", "cmd-b"]);
+    }
+
+    #[test]
+    fn test_parse_mount_string() {
+        let ws = Path::new("/home/user/project");
+        let result =
+            parse_mount_string("source=/host,target=/container,type=bind", ws, "/workspace")
+                .unwrap();
+        assert_eq!(result, "/host:/container:rw");
+
+        let result = parse_mount_string(
+            "source=${localWorkspaceFolder}/.config,target=/home/dev/.config,type=bind,readonly",
+            ws,
+            "/workspace",
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            "/home/user/project/.config:/home/dev/.config:ro"
+        );
+    }
+
+    #[test]
+    fn test_load_plan_minimal() {
+        let dir = std::env::temp_dir().join("sdme-test-devcontainer-plan");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let config_path = dir.join("devcontainer.json");
+        std::fs::write(
+            &config_path,
+            r#"{ "image": "ubuntu:22.04", "workspaceFolder": "/work" }"#,
+        )
+        .unwrap();
+
+        let plan = load_plan(&config_path, &dir).unwrap();
+        assert_eq!(plan.image.as_deref(), Some("ubuntu:22.04"));
+        assert_eq!(plan.workspace_folder, "/work");
+        // Default workspace mount
+        assert_eq!(plan.binds.len(), 1);
+        assert!(plan.binds[0].ends_with(":/work:rw"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_load_plan_no_image_or_build() {
+        let dir = std::env::temp_dir().join("sdme-test-devcontainer-plan-err");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let config_path = dir.join("devcontainer.json");
+        std::fs::write(&config_path, r#"{ "name": "test" }"#).unwrap();
+
+        let result = load_plan(&config_path, &dir);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("image"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/devcontainer/types.rs
+++ b/src/devcontainer/types.rs
@@ -1,0 +1,301 @@
+//! Serde deserialization types for devcontainer.json.
+//!
+//! These types map directly to the Dev Container specification schema.
+//! Validation and conversion to internal types happens in [`super::plan`].
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+/// Root devcontainer.json configuration.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+pub(super) struct DevcontainerConfig {
+    /// Human-readable name for the dev container.
+    pub name: Option<String>,
+
+    // --- Container source (one of these must be set) ---
+    /// OCI image reference (e.g. "ubuntu:22.04", "mcr.microsoft.com/devcontainers/base:ubuntu").
+    pub image: Option<String>,
+
+    /// Build configuration using a Dockerfile.
+    pub build: Option<BuildConfig>,
+
+    // --- Workspace ---
+    /// Override the default workspace mount (set to empty string to disable).
+    pub workspace_mount: Option<String>,
+
+    /// Path inside the container where the workspace is mounted.
+    pub workspace_folder: Option<String>,
+
+    // --- User ---
+    /// User to run commands as inside the container.
+    pub remote_user: Option<String>,
+
+    /// User to use when creating the container (affects file ownership).
+    pub container_user: Option<String>,
+
+    // --- Environment variables ---
+    /// Environment variables set at container runtime.
+    pub remote_env: Option<HashMap<String, String>>,
+
+    /// Environment variables set during container build and runtime.
+    pub container_env: Option<HashMap<String, String>>,
+
+    // --- Mounts ---
+    /// Additional mounts (bind, volume, tmpfs).
+    #[serde(default)]
+    pub mounts: Vec<MountEntry>,
+
+    // --- Ports ---
+    /// Ports to forward from the container.
+    #[serde(default)]
+    pub forward_ports: Vec<PortEntry>,
+
+    // --- Lifecycle hooks ---
+    /// Runs once when the container is first created.
+    pub on_create_command: Option<LifecycleCommand>,
+
+    /// Runs when container is created or source code changes.
+    pub update_content_command: Option<LifecycleCommand>,
+
+    /// Runs after updateContentCommand completes.
+    pub post_create_command: Option<LifecycleCommand>,
+
+    /// Runs every time the container starts.
+    pub post_start_command: Option<LifecycleCommand>,
+
+    /// Runs when a tool attaches to the container.
+    pub post_attach_command: Option<LifecycleCommand>,
+
+    // --- Features ---
+    /// Dev Container Features to install (OCI artifact references with options).
+    #[serde(default)]
+    pub features: HashMap<String, serde_json::Value>,
+
+    // --- Container runtime settings ---
+    /// Additional arguments to pass to the container runtime.
+    #[serde(default)]
+    pub run_args: Vec<String>,
+
+    /// Capabilities to add to the container.
+    #[serde(default)]
+    pub cap_add: Vec<String>,
+
+    /// Security options for the container.
+    #[serde(default)]
+    pub security_opt: Vec<String>,
+
+    /// Run an init process (PID 1) inside the container.
+    pub init: Option<bool>,
+
+    /// Run the container in privileged mode.
+    pub privileged: Option<bool>,
+
+    /// Override the default command.
+    pub override_command: Option<bool>,
+
+    /// Action to take when the tool stops: "none" or "stopContainer".
+    pub shutdown_action: Option<String>,
+
+    // --- Customizations ---
+    /// Tool-specific customizations (e.g. vscode extensions/settings).
+    pub customizations: Option<HashMap<String, serde_json::Value>>,
+}
+
+/// Dockerfile build configuration.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct BuildConfig {
+    /// Path to the Dockerfile (relative to devcontainer.json).
+    pub dockerfile: String,
+
+    /// Build context directory (relative to devcontainer.json).
+    pub context: Option<String>,
+
+    /// Build arguments.
+    #[serde(default)]
+    pub args: HashMap<String, String>,
+
+    /// Target build stage.
+    pub target: Option<String>,
+}
+
+/// A mount entry can be either a structured object or a Docker-style string.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(super) enum MountEntry {
+    /// Structured mount object.
+    Object(MountObject),
+    /// Docker CLI-style string: "source=...,target=...,type=bind".
+    String(String),
+}
+
+/// Structured mount definition.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct MountObject {
+    /// Mount type: "bind", "volume", or "tmpfs".
+    #[serde(rename = "type")]
+    pub mount_type: Option<String>,
+
+    /// Source path (host path for bind, volume name for volume).
+    pub source: Option<String>,
+
+    /// Target path inside the container.
+    pub target: String,
+
+    /// Whether the mount is read-only.
+    #[serde(default)]
+    pub readonly: bool,
+}
+
+/// A port entry can be a number or a string like "8443:8443".
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(super) enum PortEntry {
+    /// Simple port number (same port on host and container).
+    Number(u16),
+    /// Port mapping string "host:container" or just "port".
+    String(String),
+}
+
+/// A lifecycle command can be a string, array of strings, or object of parallel commands.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(super) enum LifecycleCommand {
+    /// Single command string (run via shell).
+    String(String),
+    /// Array of command strings (run sequentially).
+    Array(Vec<String>),
+    /// Named parallel commands (keys are labels, values are commands).
+    Object(HashMap<String, String>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_minimal_image() {
+        let json = r#"{ "image": "ubuntu:22.04" }"#;
+        let config: DevcontainerConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.image.as_deref(), Some("ubuntu:22.04"));
+        assert!(config.build.is_none());
+        assert!(config.name.is_none());
+    }
+
+    #[test]
+    fn test_parse_full_config() {
+        let json = r#"{
+            "name": "Test Dev Container",
+            "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+            "workspaceFolder": "/workspace",
+            "remoteUser": "vscode",
+            "remoteEnv": { "MY_VAR": "value" },
+            "containerEnv": { "BUILD_VAR": "dev" },
+            "forwardPorts": [3000, "8080:8080"],
+            "postCreateCommand": "npm install",
+            "postStartCommand": { "server": "npm start", "watcher": "npm run watch" },
+            "mounts": [
+                { "type": "bind", "source": "/host/path", "target": "/container/path" },
+                "source=/tmp,target=/tmp,type=bind"
+            ],
+            "capAdd": ["SYS_PTRACE"],
+            "features": {
+                "ghcr.io/devcontainers/features/node:1": { "version": "20" }
+            },
+            "customizations": {
+                "vscode": {
+                    "extensions": ["rust-lang.rust-analyzer"]
+                }
+            }
+        }"#;
+        let config: DevcontainerConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.name.as_deref(), Some("Test Dev Container"));
+        assert_eq!(config.workspace_folder.as_deref(), Some("/workspace"));
+        assert_eq!(config.remote_user.as_deref(), Some("vscode"));
+        assert_eq!(config.forward_ports.len(), 2);
+        assert_eq!(config.mounts.len(), 2);
+        assert_eq!(config.cap_add, vec!["SYS_PTRACE"]);
+        assert_eq!(config.features.len(), 1);
+        assert!(config.post_create_command.is_some());
+        assert!(config.post_start_command.is_some());
+    }
+
+    #[test]
+    fn test_parse_build_config() {
+        let json = r#"{
+            "build": {
+                "dockerfile": "Dockerfile",
+                "context": "..",
+                "args": { "VARIANT": "bullseye" }
+            }
+        }"#;
+        let config: DevcontainerConfig = serde_json::from_str(json).unwrap();
+        let build = config.build.unwrap();
+        assert_eq!(build.dockerfile, "Dockerfile");
+        assert_eq!(build.context.as_deref(), Some(".."));
+        assert_eq!(build.args.get("VARIANT").unwrap(), "bullseye");
+    }
+
+    #[test]
+    fn test_lifecycle_command_variants() {
+        // String
+        let json = r#"{ "postCreateCommand": "npm install" }"#;
+        let config: DevcontainerConfig = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            config.post_create_command,
+            Some(LifecycleCommand::String(_))
+        ));
+
+        // Array
+        let json = r#"{ "postCreateCommand": ["npm install", "npm build"] }"#;
+        let config: DevcontainerConfig = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            config.post_create_command,
+            Some(LifecycleCommand::Array(_))
+        ));
+
+        // Object
+        let json = r#"{ "postCreateCommand": { "install": "npm install", "build": "npm build" } }"#;
+        let config: DevcontainerConfig = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            config.post_create_command,
+            Some(LifecycleCommand::Object(_))
+        ));
+    }
+
+    #[test]
+    fn test_mount_entry_variants() {
+        let json = r#"{
+            "mounts": [
+                { "type": "bind", "source": "/src", "target": "/dst", "readonly": true },
+                "source=/a,target=/b,type=bind"
+            ]
+        }"#;
+        let config: DevcontainerConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.mounts.len(), 2);
+        match &config.mounts[0] {
+            MountEntry::Object(m) => {
+                assert_eq!(m.mount_type.as_deref(), Some("bind"));
+                assert!(m.readonly);
+            }
+            _ => panic!("expected object mount"),
+        }
+        match &config.mounts[1] {
+            MountEntry::String(s) => assert!(s.contains("source=/a")),
+            _ => panic!("expected string mount"),
+        }
+    }
+
+    #[test]
+    fn test_port_entry_variants() {
+        let json = r#"{ "forwardPorts": [3000, "8443:8443"] }"#;
+        let config: DevcontainerConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.forward_ports.len(), 2);
+        assert!(matches!(config.forward_ports[0], PortEntry::Number(3000)));
+        assert!(matches!(&config.forward_ports[1], PortEntry::String(s) if s == "8443:8443"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 //! | Module | Purpose |
 //! |--------|---------|
 //! | [`containers`] | Create, remove, join, exec, stop, list |
+//! | [`devcontainer`] | Dev Container specification support |
 //! | [`systemd`] | D-Bus helpers and template unit management |
 //! | [`import`] | Rootfs import (dir, tar, URL, OCI, QCOW2) |
 //! | [`oci`] | OCI registry, layout, app setup, blob cache |
@@ -33,6 +34,7 @@
 pub mod build;
 pub mod config;
 pub mod containers;
+pub mod devcontainer;
 pub(crate) mod copy;
 pub mod cp;
 pub(crate) mod devfd_shim;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,9 +34,9 @@
 pub mod build;
 pub mod config;
 pub mod containers;
-pub mod devcontainer;
 pub(crate) mod copy;
 pub mod cp;
+pub mod devcontainer;
 pub(crate) mod devfd_shim;
 pub(crate) mod elf;
 pub mod export;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3426,12 +3426,8 @@ fn run() -> Result<()> {
             }
             DevcontainerCommand::Exec { name, command } => {
                 let name = containers::resolve_name(&cfg.datadir, &name)?;
-                let status = devcontainer::devcontainer_exec(
-                    &cfg.datadir,
-                    &name,
-                    &command,
-                    cli.verbose,
-                )?;
+                let status =
+                    devcontainer::devcontainer_exec(&cfg.datadir, &name, &command, cli.verbose)?;
                 if !status.success() {
                     std::process::exit(status.code().unwrap_or(1));
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,8 @@ use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::Shell;
 use sdme::import::{ImportOptions, InstallPackages, OciMode};
 use sdme::{
-    check_interrupted, config, confirm, containers, cp, export, kube, lock, oci, pod, rootfs,
-    security, system_check, systemd, BindConfig, EnvConfig, NetworkConfig, ResourceLimits,
+    check_interrupted, config, confirm, containers, cp, devcontainer, export, kube, lock, oci, pod,
+    rootfs, security, system_check, systemd, BindConfig, EnvConfig, NetworkConfig, ResourceLimits,
     SecurityConfig,
 };
 
@@ -724,6 +724,68 @@ SECURITY:
     Pod YAML securityContext applies at the OCI app service level. Both layers
     are complementary and can be used together.";
 
+const DEVCONTAINER_HELP: &str = "\
+Work with Dev Container configurations (.devcontainer/devcontainer.json).
+Implements the Dev Container specification (https://containers.dev/) to create
+reproducible development environments from devcontainer.json files.
+
+WORKFLOW:
+    # Bring up a devcontainer from the current directory
+    sdme devcontainer up
+
+    # Bring up from a specific workspace
+    sdme devcontainer up --workspace-folder /path/to/project
+
+    # Execute a command inside the devcontainer
+    sdme devcontainer exec dc-myproject -- npm test
+
+    # Stop the devcontainer
+    sdme devcontainer stop dc-myproject
+
+    # Remove the devcontainer and its rootfs
+    sdme devcontainer rm dc-myproject
+
+CONFIG FILE LOCATIONS:
+    .devcontainer/devcontainer.json    (primary)
+    .devcontainer.json                 (root)
+    .devcontainer/<subdir>/devcontainer.json
+
+SUPPORTED FEATURES:
+    - image: OCI image reference (pulled and imported as sdme rootfs)
+    - workspaceFolder / workspaceMount: workspace directory mapping
+    - remoteUser / containerUser: user configuration
+    - remoteEnv / containerEnv: environment variables
+    - mounts: additional bind mounts (bind type only)
+    - forwardPorts: port forwarding via systemd-nspawn
+    - Lifecycle hooks: onCreateCommand, updateContentCommand,
+      postCreateCommand, postStartCommand, postAttachCommand
+    - features: basic support for well-known Dev Container Features
+    - capAdd: Linux capability additions
+    - JSONC (JSON with comments) support
+
+CONTAINER NAMING:
+    Containers are named dc-<project>, derived from the devcontainer name
+    or the workspace folder basename. The dc- prefix prevents collisions
+    with regular sdme containers.
+
+ENVIRONMENT:
+    The following variable substitutions are supported in devcontainer.json:
+        ${localWorkspaceFolder}           Host workspace path
+        ${containerWorkspaceFolder}       Container workspace path
+        ${localWorkspaceFolderBasename}   Workspace directory name
+        ${localEnv:VAR}                   Host environment variable
+
+NOTES:
+    Dockerfile builds (the 'build' key) are not yet supported; use 'image'
+    instead, or build the image externally and reference it.
+
+    Only bind mounts are supported; volume and tmpfs mount types are skipped
+    with a warning.
+
+    Feature installation uses simplified package manager commands for
+    well-known features (node, python, git). Full OCI feature pulling is
+    planned for a future release.";
+
 // ---------------------------------------------------------------------------
 
 #[derive(Parser)]
@@ -1135,6 +1197,10 @@ enum Command {
     /// Manage Kubernetes-compatible pods (experimental)
     #[command(name = "kube", subcommand)]
     Kube(KubeCommand),
+
+    /// Work with Dev Container configurations
+    #[command(name = "devcontainer", subcommand, after_long_help = DEVCONTAINER_HELP)]
+    Devcontainer(DevcontainerCommand),
 }
 
 #[derive(Subcommand)]
@@ -1443,6 +1509,51 @@ enum KubeConfigmapCommand {
         /// ConfigMap names
         #[arg(required = true)]
         names: Vec<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum DevcontainerCommand {
+    /// Build and start a devcontainer from devcontainer.json
+    Up {
+        /// Path to the workspace folder (default: current directory)
+        #[arg(long, default_value = ".")]
+        workspace_folder: PathBuf,
+
+        /// Explicit path to devcontainer.json (overrides auto-detection)
+        #[arg(long = "config-path")]
+        config_path: Option<PathBuf>,
+
+        /// Boot timeout in seconds (overrides config, default: 60)
+        #[arg(short, long)]
+        timeout: Option<u64>,
+
+        /// Force rebuild even if container already exists
+        #[arg(long)]
+        rebuild: bool,
+
+        /// Skip the OCI manifest cache and re-fetch from the registry
+        #[arg(long)]
+        no_cache: bool,
+    },
+    /// Execute a command inside a running devcontainer
+    Exec {
+        /// Devcontainer name
+        name: String,
+
+        /// Command to execute
+        #[arg(last = true, required = true)]
+        command: Vec<String>,
+    },
+    /// Stop a running devcontainer
+    Stop {
+        /// Devcontainer name
+        name: String,
+    },
+    /// Remove a devcontainer and its rootfs
+    Rm {
+        /// Devcontainer name
+        name: String,
     },
 }
 
@@ -3277,6 +3388,65 @@ fn run() -> Result<()> {
                     }
                 }
             },
+        },
+        Command::Devcontainer(cmd) => match cmd {
+            DevcontainerCommand::Up {
+                workspace_folder,
+                config_path,
+                timeout,
+                rebuild,
+                no_cache,
+            } => {
+                system_check::check_systemd_version(255)?;
+                let docker_creds = docker_credentials(&cfg);
+                let docker_creds_ref = docker_creds.as_ref().map(|(u, t)| (u.as_str(), t.as_str()));
+                let mut http = cfg.http_config()?;
+                if no_cache {
+                    http.manifest_cache_ttl = 0;
+                }
+                let name = devcontainer::devcontainer_up(
+                    &cfg.datadir,
+                    &devcontainer::DevcontainerUpOptions {
+                        workspace_folder: &workspace_folder,
+                        config_path: config_path.as_deref(),
+                        docker_credentials: docker_creds_ref,
+                        cache: &blob_cache,
+                        verbose: cli.verbose,
+                        http: &http,
+                        auto_gc: cfg.auto_fs_gc,
+                        distros: &cfg.distros,
+                        boot_timeout: timeout.unwrap_or(cfg.boot_timeout),
+                        tasks_max: cfg.tasks_max,
+                        stop_timeout_terminate: cfg.stop_timeout_terminate,
+                        rebuild,
+                        interactive,
+                    },
+                )?;
+                println!("{name}");
+            }
+            DevcontainerCommand::Exec { name, command } => {
+                let name = containers::resolve_name(&cfg.datadir, &name)?;
+                let status = devcontainer::devcontainer_exec(
+                    &cfg.datadir,
+                    &name,
+                    &command,
+                    cli.verbose,
+                )?;
+                if !status.success() {
+                    std::process::exit(status.code().unwrap_or(1));
+                }
+            }
+            DevcontainerCommand::Stop { name } => {
+                let name = containers::resolve_name(&cfg.datadir, &name)?;
+                devcontainer::devcontainer_stop(&cfg.datadir, &name, cli.verbose)?;
+                println!("{name}");
+            }
+            DevcontainerCommand::Rm { name } => {
+                let name = containers::resolve_name(&cfg.datadir, &name)?;
+                eprintln!("removing devcontainer '{name}'");
+                devcontainer::devcontainer_rm(&cfg.datadir, &name, cli.verbose)?;
+                println!("{name}");
+            }
         },
         Command::Fs(cmd) => match cmd {
             RootfsCommand::Import {


### PR DESCRIPTION
Implement the Dev Container spec ([containers.dev](https://containers.dev/)) to create reproducible development environments from devcontainer.json files.

New CLI: sdme devcontainer up/exec/stop/rm

Supported features: image, workspaceFolder, workspaceMount, remoteUser, containerUser, remoteEnv, containerEnv, mounts (bind), forwardPorts, lifecycle hooks (onCreateCommand, postCreateCommand, postStartCommand, updateContentCommand, postAttachCommand), features (node, python, git), capAdd, and JSONC support.