### PR TITLE
feat: add owner-managed userns ranges

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -183,13 +183,10 @@ pub(crate) fn start_and_await_boot(cfg: &BootConfig) -> Result<()> {
             if let Some(shift_str) = state.get_nonempty("USERNS_SHIFT") {
                 if let Ok(shift) = shift_str.parse::<u64>() {
                     if let Some(conflict) = sdme::userns::check_shift_conflict(name, shift) {
-                        eprintln!(
-                            "warning: UID range {shift} conflicts with running container '{conflict}'"
-                        );
-                        eprintln!("falling back to nspawn pick (first boot may be slow)");
                         let mut state = state;
-                        state.remove("USERNS_SHIFT");
-                        let _ = state.write_to(&state_path);
+                        if handle_userns_shift_conflict(&mut state, name, shift, &conflict)? {
+                            state.write_to(&state_path)?;
+                        }
                     }
                 }
             }
@@ -229,6 +226,23 @@ pub(crate) fn start_and_await_boot(cfg: &BootConfig) -> Result<()> {
             Err(e)
         }
     }
+}
+
+fn handle_userns_shift_conflict(
+    state: &mut sdme::State,
+    name: &str,
+    shift: u64,
+    conflict: &str,
+) -> Result<bool> {
+    if state.is_yes("USERNS_MANAGED") {
+        bail!(
+            "managed UID range {shift} for container '{name}' conflicts with running container '{conflict}'"
+        );
+    }
+    eprintln!("warning: UID range {shift} conflicts with running container '{conflict}'");
+    eprintln!("falling back to nspawn pick (first boot may be slow)");
+    state.remove("USERNS_SHIFT");
+    Ok(true)
 }
 
 /// Print recent journal entries for a container whose boot failed.
@@ -370,15 +384,21 @@ pub(crate) fn probe_and_prechown(
                  eliminates this step"
             );
 
-            let shift = userns::allocate_uid_shift(datadir, name)?;
+            let state_path = datadir.join("state").join(name);
+            let mut state = sdme::State::read_from(&state_path)?;
+            let shift = match state
+                .get_nonempty("USERNS_SHIFT")
+                .and_then(|s| s.parse::<u64>().ok())
+            {
+                Some(shift) => shift,
+                None => userns::allocate_uid_shift(datadir, name)?,
+            };
             if verbose {
                 eprintln!("allocated UID shift: {shift}");
             }
             userns::prechown_overlayfs(datadir, name, lowerdir, shift)?;
 
             // Store the shift in the state file so to_nspawn_args uses it.
-            let state_path = datadir.join("state").join(name);
-            let mut state = sdme::State::read_from(&state_path)?;
             state.set("USERNS_SHIFT", shift.to_string());
             state.write_to(&state_path)?;
         }
@@ -941,4 +961,34 @@ pub(crate) fn validate_kube_oci_pod_args(datadir: &Path, oci_pod: Option<&str>) 
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_managed_userns_shift_conflict_is_error() {
+        let mut state = sdme::State::new();
+        state.set("USERNS_SHIFT", "655360");
+        state.set("USERNS_MANAGED", "yes");
+
+        let err = handle_userns_shift_conflict(&mut state, "owned", 655360, "other").unwrap_err();
+
+        assert!(
+            err.to_string().contains("managed UID range 655360"),
+            "unexpected error: {err:#}"
+        );
+        assert_eq!(state.get("USERNS_SHIFT"), Some("655360"));
+    }
+
+    #[test]
+    fn test_unmanaged_userns_shift_conflict_clears_shift() {
+        let mut state = sdme::State::new();
+        state.set("USERNS_SHIFT", "655360");
+
+        handle_userns_shift_conflict(&mut state, "owned", 655360, "other").unwrap();
+
+        assert_eq!(state.get("USERNS_SHIFT"), None);
+    }
 }

--- a/src/containers/create.rs
+++ b/src/containers/create.rs
@@ -8,8 +8,8 @@ use std::path::{Component, Path, PathBuf};
 use anyhow::{bail, Context, Result};
 
 use crate::{
-    names, rootfs, systemd, validate_name, BindConfig, EnvConfig, NetworkConfig, ResourceLimits,
-    SecurityConfig, State,
+    names, rootfs, systemd, userns, validate_name, BindConfig, EnvConfig, NetworkConfig,
+    ResourceLimits, SecurityConfig, State,
 };
 
 use super::{get_umask, resolve_rootfs, set_dir_permissions, unix_timestamp, volumes_dir};
@@ -37,6 +37,10 @@ pub struct CreateOptions {
     pub envs: EnvConfig,
     /// Security hardening configuration.
     pub security: SecurityConfig,
+    /// Host owner for a managed per-container subordinate ID allocation.
+    pub owner: Option<String>,
+    /// Pre-allocated managed subordinate ID range.
+    pub owner_allocation: Option<userns::ManagedSubidAllocation>,
     /// OCI volume mount paths from the image.
     pub oci_volumes: Vec<String>,
     /// OCI environment variables from the image.
@@ -127,12 +131,46 @@ pub fn create(datadir: &Path, opts: &CreateOptions, verbose: bool) -> Result<Str
         eprintln!("claimed state file: {}", state_path.display());
     }
 
-    match do_create(datadir, &name, &rootfs, opts, &opaque_dirs, verbose) {
+    let mut security = opts.security.clone();
+    let owner_allocation = match (&opts.owner_allocation, &opts.owner) {
+        (Some(allocation), _) => {
+            security.userns = true;
+            security.userns_shift = Some(allocation.start);
+            Some(allocation.clone())
+        }
+        (None, Some(owner)) => {
+            let allocation = match userns::allocate_managed_subids(datadir, &name, owner) {
+                Ok(allocation) => allocation,
+                Err(e) => {
+                    let _ = fs::remove_file(&state_path);
+                    return Err(e);
+                }
+            };
+            security.userns = true;
+            security.userns_shift = Some(allocation.start);
+            Some(allocation)
+        }
+        (None, None) => None,
+    };
+
+    match do_create(
+        datadir,
+        &name,
+        &rootfs,
+        opts,
+        &opaque_dirs,
+        &security,
+        owner_allocation.as_ref(),
+        verbose,
+    ) {
         Ok(()) => Ok(name),
         Err(e) => {
             let container_dir = datadir.join("containers").join(&name);
             let _ = fs::remove_dir_all(&container_dir);
             let _ = fs::remove_file(&state_path);
+            if owner_allocation.is_some() {
+                let _ = userns::release_managed_subids(datadir, &name);
+            }
             Err(e)
         }
     }
@@ -144,6 +182,8 @@ fn do_create(
     rootfs: &Path,
     opts: &CreateOptions,
     opaque_dirs: &[String],
+    security: &SecurityConfig,
+    owner_allocation: Option<&userns::ManagedSubidAllocation>,
     verbose: bool,
 ) -> Result<()> {
     let container_dir = datadir.join("containers").join(name);
@@ -489,15 +529,14 @@ fn do_create(
     // drop-in to adjust the bounding set. Without this, the inner service
     // claims capabilities the container doesn't have, which causes boot
     // failures on distros where systemd enforces the mismatch (e.g. SUSE).
-    if !opts.security.drop_caps.is_empty() {
+    if !security.drop_caps.is_empty() {
         let app_names = crate::oci::rootfs::detect_all_oci_app_names(rootfs);
         if !app_names.is_empty() {
             use std::collections::HashSet;
 
             use crate::security::OCI_DEFAULT_CAPS;
 
-            let drop_set: HashSet<&str> =
-                opts.security.drop_caps.iter().map(|s| s.as_str()).collect();
+            let drop_set: HashSet<&str> = security.drop_caps.iter().map(|s| s.as_str()).collect();
             let caps: Vec<&str> = OCI_DEFAULT_CAPS
                 .iter()
                 .copied()
@@ -530,7 +569,13 @@ fn do_create(
         }
     }
 
-    opts.security.write_to_state(&mut state);
+    security.write_to_state(&mut state);
+    if let Some(allocation) = owner_allocation {
+        state.set("OWNER", allocation.owner.as_str());
+        state.set("USERNS_OWNER", allocation.owner.as_str());
+        state.set("USERNS_RANGE", allocation.count.to_string());
+        state.set("USERNS_MANAGED", "yes");
+    }
     if !opts.masked_services.is_empty() {
         state.set("MASKED_SERVICES", opts.masked_services.join(","));
     }

--- a/src/containers/manage.rs
+++ b/src/containers/manage.rs
@@ -3,34 +3,37 @@
 use std::fs;
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 
-use crate::{systemd, ResourceLimits, State};
+use crate::{systemd, userns, ResourceLimits, State};
 
 use super::{ensure_exists, volumes_dir};
 
 /// Stop a container if running, then delete its state file and overlayfs directories.
 pub fn remove(datadir: &Path, name: &str, verbose: bool) -> Result<()> {
-    ensure_exists(datadir, name)?;
+    let state_file = datadir.join("state").join(name);
+    if !state_file.exists() {
+        bail!("container does not exist: {name}");
+    }
 
     // Acquire exclusive lock to prevent removal while a build is reading from this container.
     let _lock = crate::lock::lock_exclusive(datadir, "containers", name)
         .with_context(|| format!("cannot remove container '{name}': in use"))?;
 
     // Read state before removal to check for OCI volumes and enabled state.
-    let state_file = datadir.join("state").join(name);
-    let (has_oci_volumes, is_enabled) = if state_file.exists() {
-        State::read_from(&state_file)
-            .ok()
-            .map(|s| {
-                let oci = s.get("OCI_VOLUMES").map(|v| !v.is_empty()).unwrap_or(false);
-                let enabled = s.is_yes("ENABLED");
-                (oci, enabled)
-            })
-            .unwrap_or((false, false))
+    let state = if state_file.exists() {
+        State::read_from(&state_file).ok()
     } else {
-        (false, false)
+        None
     };
+    let (has_oci_volumes, is_enabled) = state
+        .as_ref()
+        .map(|s| {
+            let oci = s.get("OCI_VOLUMES").map(|v| !v.is_empty()).unwrap_or(false);
+            let enabled = s.is_yes("ENABLED");
+            (oci, enabled)
+        })
+        .unwrap_or((false, false));
 
     // Disable the unit if it was enabled (best-effort).
     if is_enabled {
@@ -55,7 +58,9 @@ pub fn remove(datadir: &Path, name: &str, verbose: bool) -> Result<()> {
         }
     }
 
-    if state_file.exists() {
+    if let Some(state) = &state {
+        remove_state_file_after_release(datadir, name, &state_file, state, verbose)?;
+    } else if state_file.exists() {
         fs::remove_file(&state_file)
             .with_context(|| format!("failed to remove {}", state_file.display()))?;
         if verbose {
@@ -72,6 +77,36 @@ pub fn remove(datadir: &Path, name: &str, verbose: bool) -> Result<()> {
         }
     }
 
+    Ok(())
+}
+
+pub(super) fn remove_state_file_after_release(
+    datadir: &Path,
+    name: &str,
+    state_file: &Path,
+    state: &State,
+    verbose: bool,
+) -> Result<()> {
+    release_managed_subids_for_state(datadir, name, state)?;
+    if state_file.exists() {
+        fs::remove_file(state_file)
+            .with_context(|| format!("failed to remove {}", state_file.display()))?;
+        if verbose {
+            eprintln!("removed {}", state_file.display());
+        }
+    }
+    Ok(())
+}
+
+/// Release a container's managed subordinate ID allocation if its state uses one.
+pub(super) fn release_managed_subids_for_state(
+    datadir: &Path,
+    name: &str,
+    state: &State,
+) -> Result<()> {
+    if state.is_yes("USERNS_MANAGED") {
+        userns::release_managed_subids(datadir, name)?;
+    }
     Ok(())
 }
 

--- a/src/containers/tests.rs
+++ b/src/containers/tests.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use crate::testutil::TempDataDir;
+use crate::userns::ManagedSubidAllocation;
 use crate::{validate_name, State};
 
 use super::*;
@@ -109,6 +110,145 @@ fn test_create_with_name() {
 
     let state = State::read_from(&tmp.path().join("state/hello")).unwrap();
     assert_eq!(state.get("NAME"), Some("hello"));
+}
+
+#[test]
+fn test_create_with_owner_managed_userns_state() {
+    let _lock = UMASK_LOCK.lock().unwrap();
+    let tmp = tmp();
+    let opts = CreateOptions {
+        name: Some("owned".to_string()),
+        owner_allocation: Some(ManagedSubidAllocation {
+            container: "owned".to_string(),
+            owner: "alice".to_string(),
+            start: 655360,
+            count: 65536,
+        }),
+        security: crate::SecurityConfig {
+            userns: true,
+            userns_shift: Some(655360),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let name = create(tmp.path(), &opts, false).unwrap();
+    assert_eq!(name, "owned");
+
+    let state = State::read_from(&tmp.path().join("state/owned")).unwrap();
+    assert_eq!(state.get("OWNER"), Some("alice"));
+    assert_eq!(state.get("USERNS"), Some("yes"));
+    assert_eq!(state.get("USERNS_OWNER"), Some("alice"));
+    assert_eq!(state.get("USERNS_SHIFT"), Some("655360"));
+    assert_eq!(state.get("USERNS_RANGE"), Some("65536"));
+    assert_eq!(state.get("USERNS_MANAGED"), Some("yes"));
+}
+
+#[test]
+fn test_remove_releases_managed_owner_allocation() {
+    let _lock = UMASK_LOCK.lock().unwrap();
+    let tmp = tmp();
+    let opts = CreateOptions {
+        name: Some("owned".to_string()),
+        owner_allocation: Some(ManagedSubidAllocation {
+            container: "owned".to_string(),
+            owner: "alice".to_string(),
+            start: 655360,
+            count: 65536,
+        }),
+        security: crate::SecurityConfig {
+            userns: true,
+            userns_shift: Some(655360),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    create(tmp.path(), &opts, false).unwrap();
+
+    let registry_dir = tmp.path().join("subids");
+    fs::create_dir_all(&registry_dir).unwrap();
+    fs::write(
+        registry_dir.join("allocations"),
+        "CONTAINER=owned\nOWNER=alice\nSTART=655360\nCOUNT=65536\nKIND=uidgid\nSTATUS=active\nCREATED=1\n",
+    )
+    .unwrap();
+
+    let state = State::read_from(&tmp.path().join("state/owned")).unwrap();
+    super::manage::release_managed_subids_for_state(tmp.path(), "owned", &state).unwrap();
+
+    let registry = fs::read_to_string(registry_dir.join("allocations")).unwrap();
+    assert!(registry.contains("STATUS=released\n"));
+    assert!(registry.contains("RELEASED="));
+}
+
+#[test]
+fn test_remove_keeps_state_when_managed_release_fails() {
+    let tmp = tmp();
+    let state_dir = tmp.path().join("state");
+    fs::create_dir_all(&state_dir).unwrap();
+    let state_path = state_dir.join("owned");
+    let mut state = State::new();
+    state.set("NAME", "owned");
+    state.set("USERNS_MANAGED", "yes");
+    state.write_to(&state_path).unwrap();
+    let registry_dir = tmp.path().join("subids");
+    fs::create_dir_all(&registry_dir).unwrap();
+    fs::write(registry_dir.join("allocations"), "CONTAINER=owned\n").unwrap();
+
+    let err = super::manage::remove_state_file_after_release(
+        tmp.path(),
+        "owned",
+        &state_path,
+        &state,
+        false,
+    )
+    .unwrap_err();
+
+    assert!(
+        err.to_string().contains("missing OWNER"),
+        "unexpected error: {err:#}"
+    );
+    assert!(state_path.exists());
+}
+
+#[test]
+fn test_create_failure_releases_managed_owner_allocation() {
+    let _lock = UMASK_LOCK.lock().unwrap();
+    let tmp = tmp();
+    let rootfs_dir = tmp.path().join("fs/failoci");
+    fs::create_dir_all(rootfs_dir.join("oci/apps/app")).unwrap();
+    let registry_dir = tmp.path().join("subids");
+    fs::create_dir_all(&registry_dir).unwrap();
+    fs::write(
+        registry_dir.join("allocations"),
+        "CONTAINER=owned-fail\nOWNER=alice\nSTART=655360\nCOUNT=65536\nKIND=uidgid\nSTATUS=active\nCREATED=1\n",
+    )
+    .unwrap();
+
+    let opts = CreateOptions {
+        name: Some("owned-fail".to_string()),
+        rootfs: Some("failoci".to_string()),
+        owner_allocation: Some(ManagedSubidAllocation {
+            container: "owned-fail".to_string(),
+            owner: "alice".to_string(),
+            start: 655360,
+            count: 65536,
+        }),
+        oci_envs: vec!["FOO=bar".to_string()],
+        ..Default::default()
+    };
+
+    let err = create(tmp.path(), &opts, false).unwrap_err();
+    assert!(
+        err.to_string().contains("no env file found"),
+        "unexpected error: {err:#}"
+    );
+
+    let registry = fs::read_to_string(registry_dir.join("allocations")).unwrap();
+    assert!(registry.contains("STATUS=released\n"));
+    assert!(registry.contains("RELEASED="));
+    assert!(!tmp.path().join("state/owned-fail").exists());
+    assert!(!tmp.path().join("containers/owned-fail").exists());
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,9 @@ EXAMPLES:
     # Hardened security (userns, private-network, no-new-privileges, cap drops)
     sdme new sandbox -r ubuntu --hardened
 
+    # Owner-managed user namespace range
+    sdme new mybox -r ubuntu --owner alice
+
     # Strict security (hardened + Docker-equivalent caps, seccomp, AppArmor)
     sdme new jail -r ubuntu --strict
 
@@ -194,6 +197,9 @@ EXAMPLES:
 
     # User namespace isolation
     sdme create mybox -r ubuntu --userns
+
+    # Owner-managed user namespace range
+    sdme create mybox -r ubuntu --owner alice
 
     # Read-only rootfs with dropped capabilities
     sdme create mybox -r ubuntu --read-only --drop-capability CAP_NET_RAW
@@ -884,8 +890,9 @@ SECURITY:
     are complementary and can be used together.";
 
 const PRUNE_HELP: &str = "\
-Remove unused filesystems, unhealthy containers, orphaned pods, stale
-transactions, and unreferenced secrets, configmaps, and volumes.
+Remove unused filesystems, unhealthy containers, released subordinate ID
+ranges, orphaned pods, stale transactions, and unreferenced secrets,
+configmaps, and volumes.
 
 Runs an analysis phase first, displays what would be pruned, and asks
 for confirmation before proceeding. The configured default_base_fs is
@@ -910,6 +917,7 @@ EXAMPLES:
 CATEGORIES:
     Filesystems          Imported rootfs with no containers using them
     Containers           Containers with non-ok health status
+    Subordinate IDs      Released managed subuid/subgid ranges
     Pods                 Pod network namespaces with no containers attached
     Secrets              Kube secrets (copied at create time, not runtime-bound)
     ConfigMaps           Kube configmaps (copied at create time, not runtime-bound)
@@ -924,8 +932,8 @@ NOTES:
 
     The --except flag accepts plain names (matches all categories) or
     category:name prefixes to disambiguate when a name appears in
-    multiple categories. Prefixes: fs, container, pod, secret, configmap,
-    volume, txn.
+    multiple categories. Prefixes: fs, container, subid, pod, secret,
+    configmap, volume, txn.
 
     The OCI blob cache is not pruned. It has its own size-based eviction
     (oci_cache_max_size) and can be cleaned with 'sdme fs cache clean'.";
@@ -1003,6 +1011,10 @@ enum Command {
     Create {
         /// Container name (generated if not provided)
         name: Option<String>,
+
+        /// Host owner for managed per-container user namespace range
+        #[arg(long)]
+        owner: Option<String>,
 
         /// Root filesystem to use (host filesystem if not provided)
         #[arg(short = 'r', long = "fs")]
@@ -1162,6 +1174,10 @@ enum Command {
     New {
         /// Container name (generated if not provided)
         name: Option<String>,
+
+        /// Host owner for managed per-container user namespace range
+        #[arg(long)]
+        owner: Option<String>,
 
         /// Root filesystem to use (host filesystem if not provided)
         #[arg(short = 'r', long = "fs")]
@@ -2160,6 +2176,7 @@ fn run() -> Result<()> {
         }
         Command::Create {
             name,
+            owner,
             fs,
             memory,
             cpus,
@@ -2230,10 +2247,11 @@ fn run() -> Result<()> {
                     .to_string(),
                 None => "/".to_string(),
             };
-            let userns_enabled = sec.userns;
+            let userns_enabled = sec.userns || owner.is_some();
 
             let opts = containers::CreateOptions {
                 name,
+                owner,
                 rootfs: fs,
                 limits,
                 network,
@@ -2243,6 +2261,7 @@ fn run() -> Result<()> {
                 binds,
                 envs,
                 security: sec,
+                owner_allocation: None,
                 oci_volumes,
                 oci_envs,
                 masked_services,
@@ -2489,6 +2508,7 @@ fn run() -> Result<()> {
         }
         Command::New {
             name,
+            owner,
             fs,
             timeout,
             user,
@@ -2560,10 +2580,11 @@ fn run() -> Result<()> {
                     .to_string(),
                 None => "/".to_string(),
             };
-            let userns_enabled = sec.userns;
+            let userns_enabled = sec.userns || owner.is_some();
 
             let opts = containers::CreateOptions {
                 name,
+                owner,
                 rootfs: fs,
                 limits,
                 network,
@@ -2573,6 +2594,7 @@ fn run() -> Result<()> {
                 binds,
                 envs,
                 security: sec,
+                owner_allocation: None,
                 oci_volumes,
                 oci_envs,
                 masked_services,
@@ -3646,6 +3668,24 @@ mod tests {
         assert!(network.ports.contains(&"tcp:443:443".to_string()));
 
         let _ = fs::remove_dir_all(&rootfs);
+    }
+
+    #[test]
+    fn test_create_owner_cli_parses() {
+        let cli = Cli::try_parse_from(["sdme", "create", "mybox", "--owner", "alice"]).unwrap();
+        match cli.command {
+            Command::Create { owner, .. } => assert_eq!(owner.as_deref(), Some("alice")),
+            _ => panic!("expected create command"),
+        }
+    }
+
+    #[test]
+    fn test_new_owner_cli_parses() {
+        let cli = Cli::try_parse_from(["sdme", "new", "mybox", "--owner", "alice"]).unwrap();
+        match cli.command {
+            Command::New { owner, .. } => assert_eq!(owner.as_deref(), Some("alice")),
+            _ => panic!("expected new command"),
+        }
     }
 
     #[test]

--- a/src/prune.rs
+++ b/src/prune.rs
@@ -13,7 +13,7 @@ use anyhow::{Context, Result};
 
 use std::sync::atomic::Ordering;
 
-use crate::{check_interrupted, containers, kube, pod, rootfs, txn, State, INTERRUPTED};
+use crate::{check_interrupted, containers, kube, pod, rootfs, txn, userns, State, INTERRUPTED};
 
 /// Category of a prunable resource, ordered by display and removal priority.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -22,6 +22,8 @@ pub enum PruneCategory {
     Filesystem,
     /// Container with unhealthy status.
     Container,
+    /// Released managed subordinate UID/GID range.
+    SubId,
     /// Pod with no containers attached.
     Pod,
     /// Kube secret (copied at create time, not runtime-bound).
@@ -40,6 +42,7 @@ impl PruneCategory {
         match self {
             Self::Filesystem => "fs",
             Self::Container => "container",
+            Self::SubId => "subid",
             Self::Pod => "pod",
             Self::Secret => "secret",
             Self::ConfigMap => "configmap",
@@ -53,6 +56,7 @@ impl PruneCategory {
         match self {
             Self::Filesystem => "Filesystems",
             Self::Container => "Containers",
+            Self::SubId => "Subordinate ID ranges",
             Self::Pod => "Pods",
             Self::Secret => "Secrets",
             Self::ConfigMap => "ConfigMaps",
@@ -63,9 +67,10 @@ impl PruneCategory {
 }
 
 /// Display ordering of categories: filesystems first, stale transactions last.
-const DISPLAY_ORDER: [PruneCategory; 7] = [
+const DISPLAY_ORDER: [PruneCategory; 8] = [
     PruneCategory::Filesystem,
     PruneCategory::Container,
+    PruneCategory::SubId,
     PruneCategory::Pod,
     PruneCategory::Secret,
     PruneCategory::ConfigMap,
@@ -75,10 +80,11 @@ const DISPLAY_ORDER: [PruneCategory; 7] = [
 
 /// Removal ordering: stale transactions first (no lock), then follows lock
 /// ordering (fs, containers, pods, secrets, configmaps), volumes last.
-const REMOVAL_ORDER: [PruneCategory; 7] = [
+const REMOVAL_ORDER: [PruneCategory; 8] = [
     PruneCategory::StaleTransaction,
     PruneCategory::Filesystem,
     PruneCategory::Container,
+    PruneCategory::SubId,
     PruneCategory::Pod,
     PruneCategory::Secret,
     PruneCategory::ConfigMap,
@@ -143,7 +149,21 @@ pub fn analyze(datadir: &Path, default_base_fs: &str) -> Result<Vec<PrunableItem
 
     check_interrupted()?;
 
-    // 3. Unused pods: no containers reference them.
+    // 3. Released managed subid allocations with exact host file lines.
+    for allocation in userns::released_managed_subids(datadir)? {
+        items.push(PrunableItem {
+            category: PruneCategory::SubId,
+            name: allocation.container,
+            reason: format!(
+                "released managed range {}:{} for {}",
+                allocation.start, allocation.count, allocation.owner
+            ),
+        });
+    }
+
+    check_interrupted()?;
+
+    // 4. Unused pods: no containers reference them.
     let pod_entries = pod::list(datadir)?;
     for p in &pod_entries {
         if p.containers.is_empty() {
@@ -157,7 +177,7 @@ pub fn analyze(datadir: &Path, default_base_fs: &str) -> Result<Vec<PrunableItem
 
     check_interrupted()?;
 
-    // 4. All secrets (copied at create time, not runtime-bound).
+    // 5. All secrets (copied at create time, not runtime-bound).
     let secrets = kube::secret::list(datadir)?;
     for s in &secrets {
         items.push(PrunableItem {
@@ -169,7 +189,7 @@ pub fn analyze(datadir: &Path, default_base_fs: &str) -> Result<Vec<PrunableItem
 
     check_interrupted()?;
 
-    // 5. All configmaps (copied at create time, not runtime-bound).
+    // 6. All configmaps (copied at create time, not runtime-bound).
     let configmaps = kube::configmap::list(datadir)?;
     for cm in &configmaps {
         items.push(PrunableItem {
@@ -181,7 +201,7 @@ pub fn analyze(datadir: &Path, default_base_fs: &str) -> Result<Vec<PrunableItem
 
     check_interrupted()?;
 
-    // 6. Orphaned volumes: no container references the volume path.
+    // 7. Orphaned volumes: no container references the volume path.
     let volumes_dir = datadir.join("volumes");
     if volumes_dir.is_dir() {
         // Collect all BINDS values from container state files for matching.
@@ -228,7 +248,7 @@ pub fn analyze(datadir: &Path, default_base_fs: &str) -> Result<Vec<PrunableItem
 
     check_interrupted()?;
 
-    // 7. Stale transaction staging directories.
+    // 8. Stale transaction staging directories.
     let fs_dir = datadir.join("fs");
     let stale = txn::find_all_stale_txns(&fs_dir)?;
     for path in &stale {
@@ -355,6 +375,7 @@ pub fn execute(
                 }
                 PruneCategory::Filesystem => rootfs::remove(datadir, &item.name, auto_gc, verbose),
                 PruneCategory::Container => containers::remove(datadir, &item.name, verbose),
+                PruneCategory::SubId => userns::prune_managed_subid(datadir, &item.name),
                 PruneCategory::Pod => pod::remove(datadir, &item.name, true, verbose),
                 PruneCategory::Secret => {
                     kube::secret::remove(datadir, std::slice::from_ref(&item.name))
@@ -462,6 +483,7 @@ mod tests {
         let categories = [
             PruneCategory::Filesystem,
             PruneCategory::Container,
+            PruneCategory::SubId,
             PruneCategory::Pod,
             PruneCategory::Secret,
             PruneCategory::ConfigMap,

--- a/src/systemd/tests.rs
+++ b/src/systemd/tests.rs
@@ -103,6 +103,31 @@ fn test_nspawn_dropin_with_userns() {
 }
 
 #[test]
+fn test_nspawn_dropin_with_owner_userns_shift() {
+    let paths = test_paths();
+    let mut state = crate::State::new();
+    state.set("USERNS", "yes");
+    state.set("USERNS_SHIFT", "655360");
+    state.set("USERNS_RANGE", "65536");
+    state.set("USERNS_MANAGED", "yes");
+    state.set("USERNS_OWNER", "alice");
+    let args = SecurityConfig::from_state(&state).to_nspawn_args(255);
+    let content = nspawn_dropin(&DropinConfig {
+        datadir: "/var/lib/sdme",
+        name: "ownedbox",
+        lowerdir: "/",
+        paths: &paths,
+        nspawn_args: &args,
+        service_directives: &[],
+        submounts: &[],
+        pod_netns: None,
+    });
+    assert!(content.contains("--private-users=655360:65536"));
+    assert!(content.contains("--private-users-ownership=auto"));
+    assert!(!content.contains("--private-users=pick"));
+}
+
+#[test]
 fn test_nspawn_dropin_with_pod_netns() {
     let paths = test_paths();
     let args = vec![
@@ -128,6 +153,35 @@ fn test_nspawn_dropin_with_pod_netns() {
     assert!(content.contains("--private-users=pick"));
     assert!(content.contains("--boot"));
     // --network-namespace-path should NOT appear.
+    assert!(!content.contains("--network-namespace-path"));
+}
+
+#[test]
+fn test_nspawn_dropin_with_pod_netns_and_owner_userns_shift() {
+    let paths = test_paths();
+    let mut state = crate::State::new();
+    state.set("USERNS", "yes");
+    state.set("USERNS_SHIFT", "655360");
+    state.set("USERNS_RANGE", "65536");
+    state.set("USERNS_MANAGED", "yes");
+    state.set("USERNS_OWNER", "alice");
+    let args = SecurityConfig::from_state(&state).to_nspawn_args(255);
+    let content = nspawn_dropin(&DropinConfig {
+        datadir: "/var/lib/sdme",
+        name: "podbox",
+        lowerdir: "/",
+        paths: &paths,
+        nspawn_args: &args,
+        service_directives: &[],
+        submounts: &[],
+        pod_netns: Some("/run/sdme/pods/mypod/netns"),
+    });
+    assert!(content.contains(
+        "ExecStart=/usr/bin/nsenter --net=/run/sdme/pods/mypod/netns -- /usr/bin/systemd-nspawn"
+    ));
+    assert!(content.contains("--private-users=655360:65536"));
+    assert!(content.contains("--private-users-ownership=auto"));
+    assert!(!content.contains("--private-users=pick"));
     assert!(!content.contains("--network-namespace-path"));
 }
 

--- a/src/userns.rs
+++ b/src/userns.rs
@@ -16,9 +16,10 @@
 
 use std::collections::HashSet;
 use std::fs;
-use std::os::unix::fs::MetadataExt;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{bail, Context, Result};
 use rayon::prelude::*;
@@ -45,6 +46,600 @@ const SIPHASH_KEY: [u8; 16] = [
 
 /// Maximum allocation attempts before giving up.
 const MAX_RETRIES: u32 = 100;
+
+/// A managed subordinate UID/GID allocation owned by sdme.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedSubidAllocation {
+    /// Container that owns the allocation.
+    pub container: String,
+    /// Host passwd owner recorded in `/etc/subuid` and `/etc/subgid`.
+    pub owner: String,
+    /// First host UID/GID in the range.
+    pub start: u64,
+    /// Number of UIDs/GIDs in the range.
+    pub count: u64,
+}
+
+impl ManagedSubidAllocation {
+    fn exact_line(&self) -> String {
+        format!("{}:{}:{}", self.owner, self.start, self.count)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ManagedSubidRecord {
+    allocation: ManagedSubidAllocation,
+    status: String,
+    created: String,
+    released: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SubidRange {
+    owner: String,
+    start: u64,
+    count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FileSnapshot {
+    existed: bool,
+    content: String,
+}
+
+impl SubidRange {
+    fn id_range(&self) -> IdRange {
+        IdRange {
+            start: self.start,
+            count: self.count,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct IdRange {
+    start: u64,
+    count: u64,
+}
+
+impl IdRange {
+    fn end(&self) -> Option<u64> {
+        self.start.checked_add(self.count)
+    }
+
+    fn overlaps(&self, other: &Self) -> bool {
+        let Some(end) = self.end() else {
+            return true;
+        };
+        let Some(other_end) = other.end() else {
+            return true;
+        };
+        self.start < other_end && other.start < end
+    }
+}
+
+/// Allocate and persist a managed subordinate UID/GID range for a container.
+///
+/// The owner must resolve via the host passwd database. This writes matching
+/// entries to `/etc/subuid` and `/etc/subgid`, then records the allocation in
+/// sdme's managed subid registry.
+pub fn allocate_managed_subids(
+    datadir: &Path,
+    container: &str,
+    owner: &str,
+) -> Result<ManagedSubidAllocation> {
+    validate_owner_exists(owner)?;
+    allocate_managed_subids_with_paths(
+        datadir,
+        container,
+        owner,
+        Path::new("/etc/subuid"),
+        Path::new("/etc/subgid"),
+    )
+}
+
+/// Validate that an owner name is safe for subid files and exists on the host.
+pub fn validate_owner_exists(owner: &str) -> Result<()> {
+    validate_owner_name(owner)?;
+    let c_owner = std::ffi::CString::new(owner).context("owner contains null byte")?;
+    let passwd = unsafe { libc::getpwnam(c_owner.as_ptr()) };
+    if passwd.is_null() {
+        bail!("owner user not found: {owner}");
+    }
+    Ok(())
+}
+
+/// Mark active managed subordinate ID allocations for a container as released.
+///
+/// This updates only sdme's registry. It intentionally leaves `/etc/subuid`
+/// and `/etc/subgid` unchanged so cleanup remains explicit through prune.
+pub fn release_managed_subids(datadir: &Path, container: &str) -> Result<()> {
+    let _lock = lock::lock_exclusive(datadir, "userns", "subid")
+        .context("cannot lock managed subid release")?;
+    let mut records = read_registry_records(datadir)?;
+    let released = unix_timestamp().to_string();
+    let mut changed = false;
+
+    for record in &mut records {
+        if record.allocation.container == container && record.status == "active" {
+            record.status = "released".to_string();
+            record.released = Some(released.clone());
+            changed = true;
+        }
+    }
+
+    if changed {
+        write_registry_records(datadir, &records)?;
+    }
+    Ok(())
+}
+
+/// Return released managed allocations that still have exact subid lines.
+///
+/// If `/etc/subuid` and `/etc/subgid` disagree for a released managed record,
+/// this returns an error and leaves both files untouched.
+pub fn released_managed_subids(datadir: &Path) -> Result<Vec<ManagedSubidAllocation>> {
+    released_managed_subids_with_paths(datadir, Path::new("/etc/subuid"), Path::new("/etc/subgid"))
+}
+
+/// Remove exact subuid/subgid lines for a released managed allocation.
+///
+/// The registry entry is marked `pruned` after the exact lines are absent
+/// from both files. Entries still referenced by live container state are not
+/// pruned.
+pub fn prune_managed_subid(datadir: &Path, container: &str) -> Result<()> {
+    prune_managed_subid_with_paths(
+        datadir,
+        container,
+        Path::new("/etc/subuid"),
+        Path::new("/etc/subgid"),
+    )
+}
+
+fn released_managed_subids_with_paths(
+    datadir: &Path,
+    subuid_path: &Path,
+    subgid_path: &Path,
+) -> Result<Vec<ManagedSubidAllocation>> {
+    let records = read_registry_records(datadir)?;
+    let subuid_content = read_optional_file(subuid_path)?;
+    let subgid_content = read_optional_file(subgid_path)?;
+    let mut released = Vec::new();
+
+    for record in records.iter().filter(|record| record.status == "released") {
+        if live_state_references_allocation(datadir, &record.allocation)? {
+            continue;
+        }
+        let line = record.allocation.exact_line();
+        match (
+            has_exact_line(&subuid_content, &line),
+            has_exact_line(&subgid_content, &line),
+        ) {
+            (true, true) => released.push(record.allocation.clone()),
+            (false, false) => {}
+            _ => bail!(
+                "subuid/subgid mismatch for managed allocation {}:{}:{}",
+                record.allocation.owner,
+                record.allocation.start,
+                record.allocation.count
+            ),
+        }
+    }
+
+    Ok(released)
+}
+
+fn prune_managed_subid_with_paths(
+    datadir: &Path,
+    container: &str,
+    subuid_path: &Path,
+    subgid_path: &Path,
+) -> Result<()> {
+    let _lock = lock::lock_exclusive(datadir, "userns", "subid")
+        .context("cannot lock managed subid prune")?;
+    let mut records = read_registry_records(datadir)?;
+    let Some(idx) = records
+        .iter()
+        .position(|record| record.allocation.container == container && record.status == "released")
+    else {
+        bail!("released managed subid allocation not found for container: {container}");
+    };
+
+    let allocation = records[idx].allocation.clone();
+    if live_state_references_allocation(datadir, &allocation)? {
+        bail!("managed subid allocation for '{container}' is still referenced by container state");
+    }
+
+    let line = allocation.exact_line();
+    let subuid_snapshot = read_file_snapshot(subuid_path)?;
+    let subgid_snapshot = read_file_snapshot(subgid_path)?;
+    match (
+        has_exact_line(&subuid_snapshot.content, &line),
+        has_exact_line(&subgid_snapshot.content, &line),
+    ) {
+        (true, true) => {
+            remove_exact_line(subuid_path, &line, 0o644)?;
+            if let Err(e) = remove_exact_line(subgid_path, &line, 0o644) {
+                let _ = restore_file_snapshot(subuid_path, &subuid_snapshot, 0o644);
+                return Err(e);
+            }
+        }
+        (false, false) => {}
+        _ => bail!(
+            "subuid/subgid mismatch for managed allocation {}:{}:{}",
+            allocation.owner,
+            allocation.start,
+            allocation.count
+        ),
+    }
+
+    records[idx].status = "pruned".to_string();
+    if let Err(e) = write_registry_records(datadir, &records) {
+        let _ = restore_file_snapshot(subgid_path, &subgid_snapshot, 0o644);
+        let _ = restore_file_snapshot(subuid_path, &subuid_snapshot, 0o644);
+        return Err(e);
+    }
+    Ok(())
+}
+
+fn allocate_managed_subids_with_paths(
+    datadir: &Path,
+    container: &str,
+    owner: &str,
+    subuid_path: &Path,
+    subgid_path: &Path,
+) -> Result<ManagedSubidAllocation> {
+    validate_owner_name(owner)?;
+    let _lock = lock::lock_exclusive(datadir, "userns", "subid")
+        .context("cannot lock managed subid allocation")?;
+
+    let subuid_snapshot = read_file_snapshot(subuid_path)?;
+    let subgid_snapshot = read_file_snapshot(subgid_path)?;
+    let subuid_ranges = parse_subid_ranges(&subuid_snapshot.content)
+        .with_context(|| format!("failed to parse {}", subuid_path.display()))?;
+    let subgid_ranges = parse_subid_ranges(&subgid_snapshot.content)
+        .with_context(|| format!("failed to parse {}", subgid_path.display()))?;
+    let occupied = collect_occupied_subid_ranges(datadir, &subuid_ranges, &subgid_ranges)?;
+    let start = first_free_subid_start(&occupied)?;
+
+    let allocation = ManagedSubidAllocation {
+        container: container.to_string(),
+        owner: owner.to_string(),
+        start,
+        count: UID_RANGE,
+    };
+    let line = allocation.exact_line();
+    append_exact_line(subuid_path, &line, 0o644)?;
+    if let Err(e) = append_exact_line(subgid_path, &line, 0o644) {
+        let _ = restore_file_snapshot(subuid_path, &subuid_snapshot, 0o644);
+        return Err(e);
+    }
+    if let Err(e) = append_registry_record(datadir, &allocation) {
+        let _ = restore_file_snapshot(subgid_path, &subgid_snapshot, 0o644);
+        let _ = restore_file_snapshot(subuid_path, &subuid_snapshot, 0o644);
+        return Err(e);
+    }
+    Ok(allocation)
+}
+
+fn validate_owner_name(owner: &str) -> Result<()> {
+    if owner.is_empty() {
+        bail!("owner cannot be empty");
+    }
+    if owner.contains(':') || owner.contains('\n') || owner.contains('\r') {
+        bail!("owner contains characters that are invalid in subid files: {owner}");
+    }
+    Ok(())
+}
+
+fn parse_subid_ranges(content: &str) -> Result<Vec<SubidRange>> {
+    let mut ranges = Vec::new();
+    for (idx, raw) in content.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let parts: Vec<&str> = line.split(':').collect();
+        if parts.len() != 3 || parts[0].is_empty() {
+            bail!("invalid subid line {}: {line}", idx + 1);
+        }
+        let start = parts[1]
+            .parse::<u64>()
+            .with_context(|| format!("invalid subid start on line {}: {line}", idx + 1))?;
+        let count = parts[2]
+            .parse::<u64>()
+            .with_context(|| format!("invalid subid count on line {}: {line}", idx + 1))?;
+        if count == 0 || start.checked_add(count).is_none() {
+            bail!("invalid subid range on line {}: {line}", idx + 1);
+        }
+        ranges.push(SubidRange {
+            owner: parts[0].to_string(),
+            start,
+            count,
+        });
+    }
+    Ok(ranges)
+}
+
+fn collect_occupied_subid_ranges(
+    datadir: &Path,
+    subuid_ranges: &[SubidRange],
+    subgid_ranges: &[SubidRange],
+) -> Result<Vec<IdRange>> {
+    let mut occupied: Vec<IdRange> = subuid_ranges.iter().map(SubidRange::id_range).collect();
+    occupied.extend(subgid_ranges.iter().map(SubidRange::id_range));
+
+    let state_dir = datadir.join("state");
+    if let Ok(entries) = fs::read_dir(&state_dir) {
+        for entry in entries.flatten() {
+            if let Ok(state) = State::read_from(&entry.path()) {
+                if let Some(start) = state
+                    .get_nonempty("USERNS_SHIFT")
+                    .and_then(|s| s.parse::<u64>().ok())
+                {
+                    let count = state
+                        .get_nonempty("USERNS_RANGE")
+                        .and_then(|s| s.parse::<u64>().ok())
+                        .unwrap_or(UID_RANGE);
+                    occupied.push(IdRange { start, count });
+                }
+            }
+        }
+    }
+
+    for (_, shift) in running_machine_shifts() {
+        occupied.push(IdRange {
+            start: shift,
+            count: UID_RANGE,
+        });
+    }
+
+    for record in read_registry_records(datadir)? {
+        if record.status != "pruned" {
+            occupied.push(IdRange {
+                start: record.allocation.start,
+                count: record.allocation.count,
+            });
+        }
+    }
+
+    Ok(occupied)
+}
+
+fn first_free_subid_start(occupied: &[IdRange]) -> Result<u64> {
+    let mut candidate = UID_BASE_MIN;
+    while candidate <= UID_BASE_MAX {
+        let range = IdRange {
+            start: candidate,
+            count: UID_RANGE,
+        };
+        if !occupied.iter().any(|used| range.overlaps(used)) {
+            return Ok(candidate);
+        }
+        candidate = match candidate.checked_add(UID_RANGE) {
+            Some(next) => next,
+            None => break,
+        };
+    }
+    bail!("failed to allocate managed subordinate ID range (all slots in use)")
+}
+
+fn append_exact_line(path: &Path, line: &str, default_mode: u32) -> Result<()> {
+    let mut content = read_optional_file(path)?;
+    if has_exact_line(&content, line) {
+        return Ok(());
+    }
+    if !content.is_empty() && !content.ends_with('\n') {
+        content.push('\n');
+    }
+    content.push_str(line);
+    content.push('\n');
+    atomic_write_preserve_mode(path, content.as_bytes(), default_mode)
+}
+
+fn remove_exact_line(path: &Path, line: &str, default_mode: u32) -> Result<()> {
+    let content = read_optional_file(path)?;
+    let mut out = String::new();
+    for existing in content.lines() {
+        if existing == line {
+            continue;
+        }
+        out.push_str(existing);
+        out.push('\n');
+    }
+    atomic_write_preserve_mode(path, out.as_bytes(), default_mode)
+}
+
+fn has_exact_line(content: &str, line: &str) -> bool {
+    content.lines().any(|existing| existing == line)
+}
+
+fn live_state_references_allocation(
+    datadir: &Path,
+    allocation: &ManagedSubidAllocation,
+) -> Result<bool> {
+    let state_dir = datadir.join("state");
+    if !state_dir.is_dir() {
+        return Ok(false);
+    }
+    for entry in fs::read_dir(&state_dir)
+        .with_context(|| format!("failed to read {}", state_dir.display()))?
+    {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let state = State::read_from(&entry.path())?;
+        let start = state
+            .get_nonempty("USERNS_SHIFT")
+            .and_then(|s| s.parse::<u64>().ok());
+        let count = state
+            .get_nonempty("USERNS_RANGE")
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(UID_RANGE);
+        if start == Some(allocation.start) && count == allocation.count {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn append_registry_record(datadir: &Path, allocation: &ManagedSubidAllocation) -> Result<()> {
+    let path = registry_path(datadir);
+    ensure_registry_dir(datadir)?;
+    let mut content = read_optional_file(&path)?;
+    if !content.is_empty() {
+        if !content.ends_with('\n') {
+            content.push('\n');
+        }
+        content.push('\n');
+    }
+    content.push_str(&format!(
+        "CONTAINER={}\nOWNER={}\nSTART={}\nCOUNT={}\nKIND=uidgid\nSTATUS=active\nCREATED={}\n",
+        allocation.container,
+        allocation.owner,
+        allocation.start,
+        allocation.count,
+        unix_timestamp()
+    ));
+    atomic_write_preserve_mode(&path, content.as_bytes(), 0o600)
+}
+
+fn read_registry_records(datadir: &Path) -> Result<Vec<ManagedSubidRecord>> {
+    let content = read_optional_file(&registry_path(datadir))?;
+    let mut records = Vec::new();
+    let mut block = Vec::new();
+
+    for line in content.lines() {
+        if line.trim().is_empty() {
+            parse_registry_block(&block, &mut records)?;
+            block.clear();
+        } else {
+            block.push(line.to_string());
+        }
+    }
+    parse_registry_block(&block, &mut records)?;
+    Ok(records)
+}
+
+fn parse_registry_block(lines: &[String], records: &mut Vec<ManagedSubidRecord>) -> Result<()> {
+    if lines.is_empty() {
+        return Ok(());
+    }
+    let mut content = lines.join("\n");
+    content.push('\n');
+    let state = State::parse(&content).context("failed to parse managed subid registry")?;
+    let container = state
+        .get_nonempty("CONTAINER")
+        .context("managed subid registry record missing CONTAINER")?;
+    let owner = state
+        .get_nonempty("OWNER")
+        .context("managed subid registry record missing OWNER")?;
+    let start = state
+        .get_nonempty("START")
+        .context("managed subid registry record missing START")?
+        .parse::<u64>()
+        .context("managed subid registry record has invalid START")?;
+    let count = state
+        .get_nonempty("COUNT")
+        .context("managed subid registry record missing COUNT")?
+        .parse::<u64>()
+        .context("managed subid registry record has invalid COUNT")?;
+    let status = state
+        .get_nonempty("STATUS")
+        .context("managed subid registry record missing STATUS")?;
+    let created = state.get("CREATED").unwrap_or("").to_string();
+    records.push(ManagedSubidRecord {
+        allocation: ManagedSubidAllocation {
+            container: container.to_string(),
+            owner: owner.to_string(),
+            start,
+            count,
+        },
+        status: status.to_string(),
+        created,
+        released: state.get_nonempty("RELEASED").map(String::from),
+    });
+    Ok(())
+}
+
+fn write_registry_records(datadir: &Path, records: &[ManagedSubidRecord]) -> Result<()> {
+    ensure_registry_dir(datadir)?;
+    let path = registry_path(datadir);
+    let mut content = String::new();
+    for (idx, record) in records.iter().enumerate() {
+        if idx > 0 {
+            content.push('\n');
+        }
+        content.push_str(&format!(
+            "CONTAINER={}\nOWNER={}\nSTART={}\nCOUNT={}\nKIND=uidgid\nSTATUS={}\nCREATED={}\n",
+            record.allocation.container,
+            record.allocation.owner,
+            record.allocation.start,
+            record.allocation.count,
+            record.status,
+            record.created,
+        ));
+        if let Some(released) = &record.released {
+            content.push_str(&format!("RELEASED={released}\n"));
+        }
+    }
+    atomic_write_preserve_mode(&path, content.as_bytes(), 0o600)
+}
+
+fn ensure_registry_dir(datadir: &Path) -> Result<()> {
+    let dir = datadir.join("subids");
+    fs::create_dir_all(&dir).with_context(|| format!("failed to create {}", dir.display()))?;
+    fs::set_permissions(&dir, fs::Permissions::from_mode(0o700))
+        .with_context(|| format!("failed to set permissions on {}", dir.display()))?;
+    Ok(())
+}
+
+fn registry_path(datadir: &Path) -> PathBuf {
+    datadir.join("subids").join("allocations")
+}
+
+fn read_optional_file(path: &Path) -> Result<String> {
+    read_file_snapshot(path).map(|snapshot| snapshot.content)
+}
+
+fn read_file_snapshot(path: &Path) -> Result<FileSnapshot> {
+    match fs::read_to_string(path) {
+        Ok(content) => Ok(FileSnapshot {
+            existed: true,
+            content,
+        }),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(FileSnapshot {
+            existed: false,
+            content: String::new(),
+        }),
+        Err(e) => Err(e).with_context(|| format!("failed to read {}", path.display())),
+    }
+}
+
+fn restore_file_snapshot(path: &Path, snapshot: &FileSnapshot, default_mode: u32) -> Result<()> {
+    if snapshot.existed {
+        atomic_write_preserve_mode(path, snapshot.content.as_bytes(), default_mode)
+    } else if path.exists() {
+        fs::remove_file(path).with_context(|| format!("failed to remove {}", path.display()))
+    } else {
+        Ok(())
+    }
+}
+
+fn atomic_write_preserve_mode(path: &Path, data: &[u8], default_mode: u32) -> Result<()> {
+    let mode = fs::metadata(path)
+        .map(|m| m.permissions().mode() & 0o7777)
+        .unwrap_or(default_mode);
+    crate::atomic_write_mode(path, data, mode)
+}
+
+fn unix_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
 
 /// Allocate a UID shift for a container, matching nspawn's `pick` algorithm.
 ///
@@ -427,6 +1022,7 @@ fn sipround(v0: &mut u64, v1: &mut u64, v2: &mut u64, v3: &mut u64) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testutil::TempDataDir;
 
     #[test]
     fn test_hash_to_shift_alignment() {
@@ -474,5 +1070,210 @@ mod tests {
             shift, 1678049280,
             "shift for 'iporakepaba' does not match nspawn's output"
         );
+    }
+
+    #[test]
+    fn test_parse_subid_ranges() {
+        let ranges =
+            parse_subid_ranges("alice:231072:65536\n\n# comment\nbob:296608:65536\n").unwrap();
+        assert_eq!(
+            ranges,
+            vec![
+                SubidRange {
+                    owner: "alice".to_string(),
+                    start: 231072,
+                    count: 65536,
+                },
+                SubidRange {
+                    owner: "bob".to_string(),
+                    start: 296608,
+                    count: 65536,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_allocate_managed_subids_writes_identity_files_and_registry() {
+        let tmp = TempDataDir::new("managed-subids");
+        let subuid = tmp.path().join("subuid");
+        let subgid = tmp.path().join("subgid");
+        fs::write(&subuid, "root:100000:65536\nalice:524288:65536\n").unwrap();
+        fs::write(&subgid, "root:100000:65536\n").unwrap();
+
+        let state_dir = tmp.path().join("state");
+        fs::create_dir_all(&state_dir).unwrap();
+        let mut state = State::new();
+        state.set("NAME", "existing");
+        state.set("USERNS_SHIFT", "589824");
+        state.write_to(&state_dir.join("existing")).unwrap();
+
+        let allocation =
+            allocate_managed_subids_with_paths(tmp.path(), "mybox", "alice", &subuid, &subgid)
+                .unwrap();
+
+        assert_eq!(allocation.owner, "alice");
+        assert_eq!(allocation.start, 655360);
+        assert_eq!(allocation.count, 65536);
+        assert!(fs::read_to_string(&subuid)
+            .unwrap()
+            .contains("alice:655360:65536\n"));
+        assert!(fs::read_to_string(&subgid)
+            .unwrap()
+            .contains("alice:655360:65536\n"));
+
+        let registry = fs::read_to_string(tmp.path().join("subids/allocations")).unwrap();
+        assert!(registry.contains("CONTAINER=mybox\n"));
+        assert!(registry.contains("OWNER=alice\n"));
+        assert!(registry.contains("START=655360\n"));
+        assert!(registry.contains("COUNT=65536\n"));
+        assert!(registry.contains("KIND=uidgid\n"));
+        assert!(registry.contains("STATUS=active\n"));
+    }
+
+    #[test]
+    fn test_allocate_managed_subids_rolls_back_subuid_when_subgid_write_fails() {
+        let tmp = TempDataDir::new("managed-subids-rollback");
+        let subuid = tmp.path().join("subuid");
+        let subgid = tmp.path().join("missing/subgid");
+        fs::write(&subuid, "root:100000:65536\n").unwrap();
+
+        let err =
+            allocate_managed_subids_with_paths(tmp.path(), "mybox", "alice", &subuid, &subgid)
+                .unwrap_err();
+
+        assert!(
+            err.to_string().contains("subgid"),
+            "unexpected error: {err:#}"
+        );
+        assert_eq!(fs::read_to_string(&subuid).unwrap(), "root:100000:65536\n");
+        assert!(!tmp.path().join("subids/allocations").exists());
+    }
+
+    #[test]
+    fn test_release_managed_subids_marks_registry_released() {
+        let tmp = TempDataDir::new("managed-subids-release");
+        let subuid = tmp.path().join("subuid");
+        let subgid = tmp.path().join("subgid");
+        fs::write(&subuid, "").unwrap();
+        fs::write(&subgid, "").unwrap();
+        allocate_managed_subids_with_paths(tmp.path(), "mybox", "alice", &subuid, &subgid).unwrap();
+
+        release_managed_subids(tmp.path(), "mybox").unwrap();
+
+        let registry = fs::read_to_string(tmp.path().join("subids/allocations")).unwrap();
+        assert!(registry.contains("CONTAINER=mybox\n"));
+        assert!(registry.contains("STATUS=released\n"));
+        assert!(registry.contains("RELEASED="));
+        assert!(!registry.contains("STATUS=active\n"));
+        assert!(fs::read_to_string(&subuid)
+            .unwrap()
+            .contains("alice:524288:65536\n"));
+        assert!(fs::read_to_string(&subgid)
+            .unwrap()
+            .contains("alice:524288:65536\n"));
+    }
+
+    #[test]
+    fn test_released_managed_subids_lists_exact_released_lines() {
+        let tmp = TempDataDir::new("managed-subids-prune-list");
+        let subuid = tmp.path().join("subuid");
+        let subgid = tmp.path().join("subgid");
+        fs::write(&subuid, "").unwrap();
+        fs::write(&subgid, "").unwrap();
+        let allocation =
+            allocate_managed_subids_with_paths(tmp.path(), "mybox", "alice", &subuid, &subgid)
+                .unwrap();
+        release_managed_subids(tmp.path(), "mybox").unwrap();
+
+        let released = released_managed_subids_with_paths(tmp.path(), &subuid, &subgid).unwrap();
+
+        assert_eq!(released, vec![allocation]);
+    }
+
+    #[test]
+    fn test_released_managed_subids_requires_exact_lines() {
+        let tmp = TempDataDir::new("managed-subids-prune-exact");
+        let subuid = tmp.path().join("subuid");
+        let subgid = tmp.path().join("subgid");
+        fs::write(&subuid, "").unwrap();
+        fs::write(&subgid, "").unwrap();
+        allocate_managed_subids_with_paths(tmp.path(), "mybox", "alice", &subuid, &subgid).unwrap();
+        release_managed_subids(tmp.path(), "mybox").unwrap();
+        fs::write(&subuid, " alice:524288:65536\n").unwrap();
+        fs::write(&subgid, "alice:524288:65536 \n").unwrap();
+
+        let released = released_managed_subids_with_paths(tmp.path(), &subuid, &subgid).unwrap();
+
+        assert!(released.is_empty());
+    }
+
+    #[test]
+    fn test_prune_managed_subid_removes_exact_lines_and_marks_pruned() {
+        let tmp = TempDataDir::new("managed-subids-prune");
+        let subuid = tmp.path().join("subuid");
+        let subgid = tmp.path().join("subgid");
+        fs::write(&subuid, "root:100000:65536\n").unwrap();
+        fs::write(&subgid, "root:100000:65536\n").unwrap();
+        allocate_managed_subids_with_paths(tmp.path(), "mybox", "alice", &subuid, &subgid).unwrap();
+        release_managed_subids(tmp.path(), "mybox").unwrap();
+
+        prune_managed_subid_with_paths(tmp.path(), "mybox", &subuid, &subgid).unwrap();
+
+        assert_eq!(fs::read_to_string(&subuid).unwrap(), "root:100000:65536\n");
+        assert_eq!(fs::read_to_string(&subgid).unwrap(), "root:100000:65536\n");
+        let registry = fs::read_to_string(tmp.path().join("subids/allocations")).unwrap();
+        assert!(registry.contains("CONTAINER=mybox\n"));
+        assert!(registry.contains("STATUS=pruned\n"));
+        assert!(!registry.contains("STATUS=released\n"));
+    }
+
+    #[test]
+    fn test_prune_managed_subid_rejects_subid_mismatch() {
+        let tmp = TempDataDir::new("managed-subids-prune-mismatch");
+        let subuid = tmp.path().join("subuid");
+        let subgid = tmp.path().join("subgid");
+        fs::write(&subuid, "").unwrap();
+        fs::write(&subgid, "").unwrap();
+        allocate_managed_subids_with_paths(tmp.path(), "mybox", "alice", &subuid, &subgid).unwrap();
+        release_managed_subids(tmp.path(), "mybox").unwrap();
+        fs::write(&subgid, "").unwrap();
+
+        let err =
+            prune_managed_subid_with_paths(tmp.path(), "mybox", &subuid, &subgid).unwrap_err();
+
+        assert!(
+            err.to_string().contains("subuid/subgid mismatch"),
+            "unexpected error: {err:#}"
+        );
+        assert!(fs::read_to_string(&subuid)
+            .unwrap()
+            .contains("alice:524288:65536\n"));
+    }
+
+    #[test]
+    fn test_prune_managed_subid_rolls_back_subuid_when_subgid_write_fails() {
+        let tmp = TempDataDir::new("managed-subids-prune-rollback");
+        let subuid = tmp.path().join("subuid");
+        let subgid = tmp.path().join("subgid");
+        fs::write(&subuid, "").unwrap();
+        fs::write(&subgid, "").unwrap();
+        allocate_managed_subids_with_paths(tmp.path(), "mybox", "alice", &subuid, &subgid).unwrap();
+        release_managed_subids(tmp.path(), "mybox").unwrap();
+        fs::create_dir(tmp.path().join(".subgid.tmp")).unwrap();
+
+        let err =
+            prune_managed_subid_with_paths(tmp.path(), "mybox", &subuid, &subgid).unwrap_err();
+
+        assert!(
+            err.to_string().contains("subgid"),
+            "unexpected error: {err:#}"
+        );
+        assert!(fs::read_to_string(&subuid)
+            .unwrap()
+            .contains("alice:524288:65536\n"));
+        assert!(fs::read_to_string(&subgid)
+            .unwrap()
+            .contains("alice:524288:65536\n"));
     }
 }


### PR DESCRIPTION
Introduce owner-aware user namespace setup so containers get stable, per-container subordinate UID/GID ranges instead of ephemeral host mappings.

Persist assigned ranges in container state, reuse them during start, and add managed subid cleanup through prune with coverage for allocation, lifecycle, and systemd drop-ins.