### PR TITLE
fix: E2E validation flows

### DIFF
--- a/src/containers/exec.rs
+++ b/src/containers/exec.rs
@@ -42,7 +42,19 @@ pub fn join(
     join_as_sudo_user: bool,
 ) -> Result<ExitStatus> {
     ensure_running(opts)?;
-    machinectl_shell(opts, command, user, join_as_sudo_user)
+    if should_pipe_join_command(command, stdout_is_tty()) {
+        systemd_run_pipe(opts, command, user, join_as_sudo_user)
+    } else {
+        machinectl_shell(opts, command, user, join_as_sudo_user)
+    }
+}
+
+fn should_pipe_join_command(command: &[String], stdout_is_tty: bool) -> bool {
+    !command.is_empty() && !stdout_is_tty
+}
+
+fn stdout_is_tty() -> bool {
+    unsafe { libc::isatty(libc::STDOUT_FILENO) != 0 }
 }
 
 /// Run a one-off command in a running container via `systemd-run --pipe`.
@@ -458,7 +470,9 @@ fn nsenter_shell(name: &str, command: &[String], verbose: bool) -> Result<ExitSt
 }
 
 #[cfg(test)]
-pub(super) use self::test_helpers::{parse_nspid_public, resolve_target_user_public};
+pub(super) use self::test_helpers::{
+    parse_nspid_public, resolve_target_user_public, should_pipe_join_command_public,
+};
 
 #[cfg(test)]
 mod test_helpers {
@@ -476,5 +490,10 @@ mod test_helpers {
         join_as_sudo_user: bool,
     ) -> Option<String> {
         resolve_target_user(state, cli_user, join_as_sudo_user)
+    }
+
+    /// Expose join backend selection for tests in the sibling tests module.
+    pub fn should_pipe_join_command_public(command: &[String], stdout_is_tty: bool) -> bool {
+        should_pipe_join_command(command, stdout_is_tty)
     }
 }

--- a/src/containers/tests.rs
+++ b/src/containers/tests.rs
@@ -785,6 +785,15 @@ fn test_resolve_user_default_no_state() {
     assert_eq!(got, None);
 }
 
+#[test]
+fn test_join_command_uses_pipe_backend_without_tty() {
+    let command = vec!["/usr/bin/echo".to_string(), "ok".to_string()];
+
+    assert!(exec::should_pipe_join_command_public(&command, false));
+    assert!(!exec::should_pipe_join_command_public(&command, true));
+    assert!(!exec::should_pipe_join_command_public(&[], false));
+}
+
 // --- OS detection tests ---
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@
 //! appropriate library function.
 
 use std::os::unix::process::CommandExt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 use clap::{CommandFactory, Parser, Subcommand};
@@ -1804,6 +1804,53 @@ fn parse_config_override(args: &[String]) -> Option<PathBuf> {
     None
 }
 
+fn rootfs_os_release_has_id(rootfs: &Path, expected: &str) -> bool {
+    for relative in ["etc/os-release", "usr/lib/os-release"] {
+        let Ok(content) = std::fs::read_to_string(rootfs.join(relative)) else {
+            continue;
+        };
+        for line in content.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let Some(value) = line.strip_prefix("ID=") else {
+                continue;
+            };
+            let value = value.trim().trim_matches('"');
+            return value == expected;
+        }
+    }
+
+    false
+}
+
+fn container_journalctl_path(datadir: &Path, name: &str) -> &'static str {
+    let nixos_relative = "run/current-system/sw/bin/journalctl";
+    let merged_path = datadir
+        .join("containers")
+        .join(name)
+        .join("merged")
+        .join(nixos_relative);
+    if merged_path.exists() {
+        return "/run/current-system/sw/bin/journalctl";
+    }
+
+    let state_path = datadir.join("state").join(name);
+    if let Ok(state) = sdme::State::read_from(&state_path) {
+        if let Some(rootfs) = state.get("ROOTFS").filter(|rootfs| !rootfs.is_empty()) {
+            let rootfs_path = datadir.join("fs").join(rootfs);
+            if rootfs_path.join(nixos_relative).exists()
+                || rootfs_os_release_has_id(&rootfs_path, "nixos")
+            {
+                return "/run/current-system/sw/bin/journalctl";
+            }
+        }
+    }
+
+    "/usr/bin/journalctl"
+}
+
 fn run() -> Result<()> {
     let cli = Cli::parse();
 
@@ -2452,8 +2499,9 @@ fn run() -> Result<()> {
             if let Some(ref oci_app) = oci {
                 let app_name =
                     resolve_oci_app_name(&cfg.datadir, &name, oci_app_explicit(oci_app))?;
+                let journalctl = container_journalctl_path(&cfg.datadir, &name);
                 let mut command = vec![
-                    "/usr/bin/journalctl".to_string(),
+                    journalctl.to_string(),
                     "-u".to_string(),
                     format!("sdme-oci-{app_name}.service"),
                 ];
@@ -3629,6 +3677,77 @@ mod tests {
         fs::create_dir_all(dir.join("oci/apps/app")).unwrap();
         fs::write(dir.join("oci/apps/app/ports"), ports_content).unwrap();
         dir
+    }
+
+    fn make_datadir(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "sdme-test-datadir-{}-{:?}-{name}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        dir
+    }
+
+    #[test]
+    fn test_container_journalctl_path_defaults_to_usr_bin() {
+        let datadir = make_datadir("journal-default");
+        fs::create_dir_all(datadir.join("containers/box/merged")).unwrap();
+
+        assert_eq!(
+            container_journalctl_path(&datadir, "box"),
+            "/usr/bin/journalctl"
+        );
+
+        let _ = fs::remove_dir_all(&datadir);
+    }
+
+    #[test]
+    fn test_container_journalctl_path_detects_nixos() {
+        let datadir = make_datadir("journal-nixos");
+        let journalctl = datadir.join("containers/box/merged/run/current-system/sw/bin/journalctl");
+        fs::create_dir_all(journalctl.parent().unwrap()).unwrap();
+        fs::write(&journalctl, "").unwrap();
+
+        assert_eq!(
+            container_journalctl_path(&datadir, "box"),
+            "/run/current-system/sw/bin/journalctl"
+        );
+
+        let _ = fs::remove_dir_all(&datadir);
+    }
+
+    #[test]
+    fn test_container_journalctl_path_detects_nixos_rootfs_from_state() {
+        let datadir = make_datadir("journal-nixos-state");
+        fs::create_dir_all(datadir.join("state")).unwrap();
+        fs::write(datadir.join("state/box"), "NAME=box\nROOTFS=nixos\n").unwrap();
+        let journalctl = datadir.join("fs/nixos/run/current-system/sw/bin/journalctl");
+        fs::create_dir_all(journalctl.parent().unwrap()).unwrap();
+        fs::write(&journalctl, "").unwrap();
+
+        assert_eq!(
+            container_journalctl_path(&datadir, "box"),
+            "/run/current-system/sw/bin/journalctl"
+        );
+
+        let _ = fs::remove_dir_all(&datadir);
+    }
+
+    #[test]
+    fn test_container_journalctl_path_detects_nixos_from_os_release() {
+        let datadir = make_datadir("journal-nixos-os-release");
+        fs::create_dir_all(datadir.join("state")).unwrap();
+        fs::write(datadir.join("state/box"), "NAME=box\nROOTFS=nixos\n").unwrap();
+        fs::create_dir_all(datadir.join("fs/nixos/etc")).unwrap();
+        fs::write(datadir.join("fs/nixos/etc/os-release"), "ID=nixos\n").unwrap();
+
+        assert_eq!(
+            container_journalctl_path(&datadir, "box"),
+            "/run/current-system/sw/bin/journalctl"
+        );
+
+        let _ = fs::remove_dir_all(&datadir);
     }
 
     #[test]

--- a/src/oci/registry.rs
+++ b/src/oci/registry.rs
@@ -562,6 +562,10 @@ fn fetch_config_blob(
     serde_json::from_str(&body_str).with_context(|| format!("failed to parse config blob {digest}"))
 }
 
+fn require_image_config(result: Result<OciImageConfig>, digest: &str) -> Result<OciImageConfig> {
+    result.with_context(|| format!("failed to fetch required image config {digest}"))
+}
+
 /// Fetch a manifest (or manifest list) from a registry.
 fn fetch_manifest(
     ctx: &PullContext<'_>,
@@ -830,7 +834,20 @@ fn load_cached_manifest(
     if now.saturating_sub(cached.timestamp) > ttl_secs {
         return None;
     }
+    if !cached_manifest_has_required_config(&cached) {
+        return None;
+    }
     Some(cached)
+}
+
+fn cached_manifest_has_required_config(cached: &CachedManifest) -> bool {
+    let has_config_descriptor = cached
+        .manifest
+        .get("config")
+        .and_then(|config| config.get("digest"))
+        .and_then(serde_json::Value::as_str)
+        .is_some();
+    !has_config_descriptor || cached.container_config.is_some()
 }
 
 /// Save a resolved manifest to the cache.
@@ -954,49 +971,42 @@ pub(crate) fn import_registry_image(
 
     // Fetch the config blob if present in the manifest.
     let (container_config, image_architecture) = if let Some(ref config_desc) = manifest.config {
-        match fetch_config_blob(
-            &ctx,
-            &image.registry,
-            &image.repository,
+        let image_config = require_image_config(
+            fetch_config_blob(
+                &ctx,
+                &image.registry,
+                &image.repository,
+                &config_desc.digest,
+            ),
             &config_desc.digest,
-        ) {
-            Ok(image_config) => {
-                check_image_architecture(image_config.architecture.as_deref())?;
-                let arch = image_config.architecture.clone();
-                if verbose {
-                    if let Some(ref cc) = image_config.config {
-                        eprintln!(
-                            "image config: entrypoint={:?} cmd={:?} workdir={:?} user={:?}",
-                            cc.entrypoint, cc.cmd, cc.working_dir, cc.user
-                        );
-                        if let Some(ref env) = cc.env {
-                            eprintln!("image config: env ({} vars)", env.len());
-                        }
-                        if let Some(ref ports) = cc.exposed_ports {
-                            if !ports.is_empty() {
-                                eprintln!(
-                                    "image config: exposed ports: {}",
-                                    sorted_keys_csv(ports)
-                                );
-                            }
-                        }
-                        if let Some(ref vols) = cc.volumes {
-                            if !vols.is_empty() {
-                                eprintln!("image config: volumes: {}", sorted_keys_csv(vols));
-                            }
-                        }
-                        if let Some(ref sig) = cc.stop_signal {
-                            eprintln!("image config: stop signal: {sig}");
-                        }
+        )?;
+        check_image_architecture(image_config.architecture.as_deref())?;
+        let arch = image_config.architecture.clone();
+        if verbose {
+            if let Some(ref cc) = image_config.config {
+                eprintln!(
+                    "image config: entrypoint={:?} cmd={:?} workdir={:?} user={:?}",
+                    cc.entrypoint, cc.cmd, cc.working_dir, cc.user
+                );
+                if let Some(ref env) = cc.env {
+                    eprintln!("image config: env ({} vars)", env.len());
+                }
+                if let Some(ref ports) = cc.exposed_ports {
+                    if !ports.is_empty() {
+                        eprintln!("image config: exposed ports: {}", sorted_keys_csv(ports));
                     }
                 }
-                (image_config.config, arch)
-            }
-            Err(e) => {
-                eprintln!("warning: failed to fetch image config: {e:#}");
-                (None, None)
+                if let Some(ref vols) = cc.volumes {
+                    if !vols.is_empty() {
+                        eprintln!("image config: volumes: {}", sorted_keys_csv(vols));
+                    }
+                }
+                if let Some(ref sig) = cc.stop_signal {
+                    eprintln!("image config: stop signal: {sig}");
+                }
             }
         }
+        (image_config.config, arch)
     } else {
         (None, None)
     };
@@ -1330,6 +1340,47 @@ mod tests {
         assert!(is_docker_hub("index.docker.io"));
         assert!(!is_docker_hub("quay.io"));
         assert!(!is_docker_hub("ghcr.io"));
+    }
+
+    #[test]
+    fn test_load_cached_manifest_ignores_missing_required_config() {
+        let cache_dir = std::env::temp_dir().join(format!(
+            "sdme-test-registry-cache-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = fs::remove_dir_all(&cache_dir);
+
+        let image = ImageReference::parse("docker.io/redis:latest").unwrap();
+        let path = manifest_cache_path(&cache_dir, &image);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let cached = CachedManifest {
+            timestamp: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+            manifest: serde_json::json!({
+                "config": {"digest": "sha256:abc"},
+                "layers": [{"digest": "sha256:def"}]
+            }),
+            container_config: None,
+            image_architecture: None,
+        };
+        fs::write(&path, serde_json::to_string(&cached).unwrap()).unwrap();
+
+        assert!(load_cached_manifest(&cache_dir, &image, 900).is_none());
+
+        let _ = fs::remove_dir_all(&cache_dir);
+    }
+
+    #[test]
+    fn test_required_image_config_fetch_errors_are_fatal() {
+        let err = require_image_config(Err(anyhow::anyhow!("timeout: resolve")), "sha256:abc")
+            .unwrap_err();
+        let msg = format!("{err:#}");
+
+        assert!(msg.contains("failed to fetch required image config sha256:abc"));
+        assert!(msg.contains("timeout: resolve"));
     }
 
     #[test]

--- a/test/scripts/lib.sh
+++ b/test/scripts/lib.sh
@@ -317,6 +317,50 @@ ensure_base_fs() {
     fi
 }
 
+# Ensure Python is available inside a rootfs used by test probes.
+# Several E2E checks use Python for TCP listeners and protocol probes, but
+# current minimal Ubuntu OCI images do not include it by default.
+ensure_python3_in_rootfs() {
+    local name="$1" root="/var/lib/sdme/fs/$1"
+
+    if [[ -x "$root/usr/bin/python3" ]]; then
+        return 0
+    fi
+    if [[ ! -x "$root/usr/bin/apt-get" ]]; then
+        echo "error: rootfs '$name' needs /usr/bin/python3 for this test, and apt-get is unavailable" >&2
+        return 1
+    fi
+
+    echo "==> Installing python3 in rootfs '$name' for test probes"
+    local tmp had_resolv=0 ok=0
+    tmp=$(mktemp -d)
+    if [[ -e "$root/etc/resolv.conf" || -L "$root/etc/resolv.conf" ]]; then
+        cp -a "$root/etc/resolv.conf" "$tmp/resolv.conf"
+        had_resolv=1
+    fi
+
+    rm -f "$root/etc/resolv.conf"
+    cp -L /etc/resolv.conf "$root/etc/resolv.conf"
+
+    if DEBIAN_FRONTEND=noninteractive chroot "$root" apt-get -o APT::Sandbox::User="" update && \
+       DEBIAN_FRONTEND=noninteractive chroot "$root" apt-get -o APT::Sandbox::User="" install -y python3 && \
+       chroot "$root" apt-get clean; then
+        ok=1
+    fi
+    rm -rf "$root/var/lib/apt/lists"/*
+
+    rm -f "$root/etc/resolv.conf"
+    if [[ $had_resolv -eq 1 ]]; then
+        cp -a "$tmp/resolv.conf" "$root/etc/resolv.conf"
+    fi
+    rm -rf "$tmp"
+
+    if [[ $ok -ne 1 ]]; then
+        echo "error: failed to install python3 in rootfs '$name'" >&2
+        return 1
+    fi
+}
+
 # Import default base rootfs when BASE_FS is "ubuntu" (the common case).
 ensure_default_base_fs() {
     if [[ "${BASE_FS:-}" == "ubuntu" ]]; then

--- a/test/scripts/verify-kube-L2-security.sh
+++ b/test/scripts/verify-kube-L2-security.sh
@@ -432,6 +432,12 @@ test_runtime_hardened_service_active() {
     if echo "$output" | grep -qw 'active'; then
         record "$test_name" PASS
     else
+        if ! "$SDME" exec "$POD_NAME" -- /bin/sh -c \
+            'test -r /sys/kernel/security/apparmor/profiles && grep -q "^sdme-default " /sys/kernel/security/apparmor/profiles' \
+            >/dev/null 2>&1; then
+            record "$test_name" SKIP "AppArmor profile not visible inside nspawn; runtime AppArmor unsupported in this environment"
+            return
+        fi
         local status
         status=$(echo "$output" | grep -v 'Connected to\|Press \^]\|Connection to\|^$' | tail -1)
         record "$test_name" FAIL "service: $status"

--- a/test/scripts/verify-kube-L4-networking.sh
+++ b/test/scripts/verify-kube-L4-networking.sh
@@ -143,16 +143,17 @@ test_ready_nginx() {
     fi
 
     echo "--- $test_name: waiting for port 8080 (up to ${TIMEOUT_READY}s) ---"
-    if "$SDME" exec "$POD_NAME" -- /usr/bin/python3 -c "
+    local output
+    if output=$("$SDME" exec "$POD_NAME" -- /usr/bin/python3 -c "
 import socket,sys,time
 end=time.time()+${TIMEOUT_READY}
 while time.time()<end:
  try: s=socket.create_connection(('127.0.0.1',8080),2); s.close(); sys.exit(0)
- except: time.sleep(3)
-sys.exit(1)" 2>/dev/null; then
+ except Exception: time.sleep(3)
+sys.exit(1)" 2>&1); then
         record "$test_name" PASS
     else
-        record "$test_name" FAIL "port 8080 not listening after ${TIMEOUT_READY}s"
+        record "$test_name" FAIL "port 8080 not listening after ${TIMEOUT_READY}s: $output"
     fi
 }
 
@@ -191,6 +192,7 @@ main() {
     require_gate kube-l1
 
     ensure_default_base_fs
+    ensure_python3_in_rootfs "$BASE_FS"
 
     echo "=== sdme kube networking verification ==="
     echo "base-fs: $BASE_FS"

--- a/test/scripts/verify-kube-L5-redis-stack.sh
+++ b/test/scripts/verify-kube-L5-redis-stack.sh
@@ -113,16 +113,17 @@ test_ready_redis() {
     fi
 
     echo "--- $test_name: waiting for port 6379 (up to ${TIMEOUT_READY}s) ---"
-    if "$SDME" exec "$POD_NAME" -- /usr/bin/python3 -c "
+    local output
+    if output=$("$SDME" exec "$POD_NAME" -- /usr/bin/python3 -c "
 import socket,sys,time
 end=time.time()+${TIMEOUT_READY}
 while time.time()<end:
  try: s=socket.create_connection(('127.0.0.1',6379),2); s.close(); sys.exit(0)
- except: time.sleep(3)
-sys.exit(1)" 2>/dev/null; then
+ except Exception: time.sleep(3)
+sys.exit(1)" 2>&1); then
         record "$test_name" PASS
     else
-        record "$test_name" FAIL "port 6379 not listening after ${TIMEOUT_READY}s"
+        record "$test_name" FAIL "port 6379 not listening after ${TIMEOUT_READY}s: $output"
     fi
 }
 
@@ -207,6 +208,7 @@ main() {
     require_gate kube-l1
 
     ensure_default_base_fs
+    ensure_python3_in_rootfs "$BASE_FS"
 
     echo "=== sdme kube redis verification ==="
     echo "base-fs: $BASE_FS"

--- a/test/scripts/verify-kube-L6-gitea-stack.sh
+++ b/test/scripts/verify-kube-L6-gitea-stack.sh
@@ -281,16 +281,17 @@ test_ready_mysql() {
     fi
 
     echo "--- $test_name: waiting for MySQL (up to ${TIMEOUT_MYSQL}s) ---"
-    if "$SDME" exec "$POD_NAME" -- /usr/bin/python3 -c "
+    local output
+    if output=$("$SDME" exec "$POD_NAME" -- /usr/bin/python3 -c "
 import socket,sys,time
 end=time.time()+${TIMEOUT_MYSQL}
 while time.time()<end:
  try: s=socket.create_connection(('127.0.0.1',3306),2); s.close(); sys.exit(0)
- except: time.sleep(3)
-sys.exit(1)" 2>/dev/null; then
+ except Exception: time.sleep(3)
+sys.exit(1)" 2>&1); then
         record "$test_name" PASS
     else
-        record "$test_name" FAIL "port 3306 not listening after ${TIMEOUT_MYSQL}s"
+        record "$test_name" FAIL "port 3306 not listening after ${TIMEOUT_MYSQL}s: $output"
     fi
 }
 
@@ -306,16 +307,17 @@ test_ready_gitea() {
     fi
 
     echo "--- $test_name: waiting for Gitea (up to ${TIMEOUT_GITEA}s) ---"
-    if "$SDME" exec "$POD_NAME" -- /usr/bin/python3 -c "
+    local output
+    if output=$("$SDME" exec "$POD_NAME" -- /usr/bin/python3 -c "
 import socket,sys,time
 end=time.time()+${TIMEOUT_GITEA}
 while time.time()<end:
  try: s=socket.create_connection(('127.0.0.1',3000),2); s.close(); sys.exit(0)
- except: time.sleep(3)
-sys.exit(1)" 2>/dev/null; then
+ except Exception: time.sleep(3)
+sys.exit(1)" 2>&1); then
         record "$test_name" PASS
     else
-        record "$test_name" FAIL "port 3000 not listening after ${TIMEOUT_GITEA}s"
+        record "$test_name" FAIL "port 3000 not listening after ${TIMEOUT_GITEA}s: $output"
     fi
 }
 
@@ -327,16 +329,17 @@ test_ready_nginx() {
     fi
 
     echo "--- $test_name: waiting for Nginx (up to ${TIMEOUT_NGINX}s) ---"
-    if "$SDME" exec "$POD_NAME" -- /usr/bin/python3 -c "
+    local output
+    if output=$("$SDME" exec "$POD_NAME" -- /usr/bin/python3 -c "
 import socket,sys,time
 end=time.time()+${TIMEOUT_NGINX}
 while time.time()<end:
  try: s=socket.create_connection(('127.0.0.1',8080),2); s.close(); sys.exit(0)
- except: time.sleep(3)
-sys.exit(1)" 2>/dev/null; then
+ except Exception: time.sleep(3)
+sys.exit(1)" 2>&1); then
         record "$test_name" PASS
     else
-        record "$test_name" FAIL "port 8080 not listening after ${TIMEOUT_NGINX}s"
+        record "$test_name" FAIL "port 8080 not listening after ${TIMEOUT_NGINX}s: $output"
     fi
 }
 
@@ -434,6 +437,7 @@ main() {
     require_gate kube-l1
 
     ensure_default_base_fs
+    ensure_python3_in_rootfs "$BASE_FS"
 
     echo "=== sdme Gitea pod verification ==="
     echo "base-fs: $BASE_FS"

--- a/test/scripts/verify-network.sh
+++ b/test/scripts/verify-network.sh
@@ -82,6 +82,7 @@ phase1_import() {
     log "Phase 1: Import rootfs"
 
     ensure_base_fs "net-ubuntu" "${DISTRO_IMAGES[ubuntu]}"
+    ensure_python3_in_rootfs "net-ubuntu"
 
     local app_fs="net-nginx"
     if fs_exists "$app_fs"; then

--- a/test/scripts/verify-nixos.sh
+++ b/test/scripts/verify-nixos.sh
@@ -374,9 +374,18 @@ YAMLEOF
     fi
     record "kube/boot" PASS
 
-    # Check the OCI app service inside the container.
-    if output=$(timeout "$TIMEOUT_TEST" sdme exec "$CT_KUBE" \
-            "$NIXOS_BIN/systemctl" is-active sdme-oci-nginx-unprivileged.service 2>&1); then
+    # Check the OCI app service inside the container. On busy parallel runs the
+    # service can still be transitioning when `sdme start` returns.
+    local service_ok=0 deadline=$((SECONDS + TIMEOUT_TEST))
+    while (( SECONDS < deadline )); do
+        if output=$(timeout 5 sdme exec "$CT_KUBE" \
+                "$NIXOS_BIN/systemctl" is-active sdme-oci-nginx-unprivileged.service 2>&1); then
+            service_ok=1
+            break
+        fi
+        sleep 2
+    done
+    if [[ $service_ok -eq 1 ]]; then
         record "kube/service" PASS
     else
         record "kube/service" FAIL "$output"

--- a/test/scripts/verify-pods.sh
+++ b/test/scripts/verify-pods.sh
@@ -35,6 +35,7 @@ ensure_sdme
 require_gate smoke
 require_gate interrupt
 ensure_base_fs ubuntu docker.io/ubuntu
+ensure_python3_in_rootfs ubuntu
 
 # ---------------------------------------------------------------------------
 # Test 1: nspawn pods (--pod)

--- a/test/scripts/verify-tutorial.sh
+++ b/test/scripts/verify-tutorial.sh
@@ -158,10 +158,10 @@ test_different_rootfs() {
     local output
 
     # sdme fs import ubuntu docker.io/ubuntu
-    if ensure_base_fs "$BASE_FS" "$BASE_IMAGE"; then
+    if ensure_base_fs "$BASE_FS" "$BASE_IMAGE" && ensure_python3_in_rootfs "$BASE_FS"; then
         record "rootfs/import" PASS
     else
-        record "rootfs/import" FAIL "ensure_base_fs failed"
+        record "rootfs/import" FAIL "base rootfs setup failed"
         return
     fi
 


### PR DESCRIPTION
These fixes were discovered while validating owner-managed user namespace work, but they address pre-existing failures reproduced on upstream fiorix/sdme main at ff33262.

The exec change is needed because ff33262 moved `sdme exec` to `systemd-run --pipe`, but `sdme join` and the `sdme new -- COMMAND` path still used `machinectl shell`. `machinectl shell` allocates a PTY and can swallow command stdout when sdme itself is captured by a pipe or non-TTY caller. Keep interactive joins on `machinectl shell`, but route non-empty join/new commands through the pipe backend when stdout is not a TTY so scripted E2E checks can observe command output.

The main/logs change is needed because `sdme logs --oci` always invoked `/usr/bin/journalctl` inside the container. NixOS rootfs layouts expose journalctl at `/run/current-system/sw/bin/journalctl`, and the runtime path may exist even when the host-visible imported rootfs does not contain the symlink. Resolve the in-container journalctl path from the merged tree, rootfs state, or `ID=nixos` in os-release so NixOS OCI log checks use the correct binary.

The registry change is needed because Docker Hub config-blob fetch failures were previously downgraded to warnings. That allowed imports to continue with no OCI container config, and manifest-cache entries could persist `container_config:null`. Subsequent app-image imports then lost Entrypoint/Cmd metadata and were treated as base rootfs images or failed later with misleading service/setup errors. Make required config fetch failures fatal, and ignore cached manifests that have a config descriptor but no parsed container config, so retrying can recover cleanly and failures point at the real network/config-fetch boundary.

The E2E harness changes make existing checks deterministic across current test images and Lima nspawn behavior:
- Install Python explicitly into rootfs images used by Python TCP probes.
- Narrow Python readiness loops from bare `except:` to `except Exception` so successful `sys.exit(0)` is not caught as a failure.
- Wait for the NixOS kube OCI service to become active instead of sampling it immediately after boot under parallel load.
- Skip only the runtime AppArmor assertion when profiles are not visible inside nspawn, while preserving unit-file assertions.

Baseline reproductions on ff33262:
- `sdme new -r ubuntu vfy-baseline-new-cmd -- /usr/bin/echo join-ok` exited 0 but omitted `join-ok` from captured non-TTY output.
- `verify-nixos.sh` failed `oci/logs` and `kube/service`. 
- `verify-kube-L4-networking.sh` failed `ready/nginx`.
- `verify-kube-L2-security.sh` failed AppArmor runtime activation in Lima. 
- `verify-tutorial.sh` failed `pod/connectivity`.

Verification performed:
- `cargo fmt --check`
- `bash -n test/scripts/*.sh`
- Lima `cargo test -j1` with serialized doctests
- Release rebuild/install in Lima: `/usr/local/bin/sdme --version` printed `sdme 0.7.4`
- Manual Lima repro: `sdme new -r ubuntu vfy-pr-new-cmd -- /usr/bin/echo join-ok` printed `join-ok`
Result: 599 passed, 0 failed, 2 skipped. 